### PR TITLE
Version image name norming checks to main

### DIFF
--- a/.github/workflows/on_pr_checks.yml
+++ b/.github/workflows/on_pr_checks.yml
@@ -45,7 +45,7 @@ jobs:
       registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
   normalize-valid-image-name:
-    uses: brianjbayer/actions-image-cicd/.github/workflows/normalize_for_image_name.yml@add-normalize-image-name
+    uses: brianjbayer/actions-image-cicd/.github/workflows/normalize_for_image_name.yml@main
     with:
       raw_name: valid-lowercase-dashes-numbers-22
 
@@ -61,7 +61,7 @@ jobs:
         run: test "$NORM_NAME" = 'valid-lowercase-dashes-numbers-22'
 
   normalize-invalid-image-name:
-    uses: brianjbayer/actions-image-cicd/.github/workflows/normalize_for_image_name.yml@add-normalize-image-name
+    uses: brianjbayer/actions-image-cicd/.github/workflows/normalize_for_image_name.yml@main
     with:
       raw_name: "  Dependabot/bundler//nokogiri-1.13.4  "
 


### PR DESCRIPTION
# What & Why
Versions the checks for the `normalize_for_image_name` reusable workflow to main to ensure currency of software under test and to delete that feature branch.

# Change Impact Analysis and Testing
Vetted through the PR checks and visual inspection of those checks output.
