### PR TITLE
Add Branch Image Name Normalization to PR and Merge Workflows

### DIFF
--- a/.github/workflows/on_pr_checks.yml
+++ b/.github/workflows/on_pr_checks.yml
@@ -16,34 +16,6 @@ jobs:
   check-git_github_info:
     uses: brianjbayer/actions-image-cicd/.github/workflows/git_github_info.yml@main
 
-  check-build_push_image:
-    uses: brianjbayer/actions-image-cicd/.github/workflows/build_push_image.yml@main
-    with:
-      image: ${{ github.repository }}_${{ github.head_ref }}_test:${{ github.event.pull_request.head.sha }}
-    secrets:
-      registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
-      registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-
-  check-pull_push_image:
-    needs: [check-build_push_image]
-    uses: brianjbayer/actions-image-cicd/.github/workflows/pull_push_image.yml@main
-    with:
-      pull_as: ${{ github.repository }}_${{ github.head_ref }}_test:${{ github.event.pull_request.head.sha }}
-      push_as: ${{ github.repository }}_${{ github.head_ref }}:${{ github.event.pull_request.head.sha }}
-    secrets:
-      registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
-      registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-
-  check-pull_push_latest_image:
-    needs: [check-pull_push_image]
-    uses: brianjbayer/actions-image-cicd/.github/workflows/pull_push_latest_image.yml@main
-    with:
-      image_name: ${{ github.repository }}_${{ github.head_ref }}
-      image_tag: ${{ github.event.pull_request.head.sha }}
-    secrets:
-      registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
-      registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-
   normalize-valid-image-name:
     uses: brianjbayer/actions-image-cicd/.github/workflows/normalize_for_image_name.yml@main
     with:
@@ -75,3 +47,37 @@ jobs:
         run: echo "NORM_NAME=[${NORM_NAME}]"
       - name: Verify normalized name
         run: test "$NORM_NAME" = 'dependabot-bundler-nokogiri-1-13-4'
+
+  pr-norm-branch:
+    uses: brianjbayer/actions-image-cicd/.github/workflows/normalize_for_image_name.yml@main
+    with:
+      raw_name: ${{ github.head_ref }}
+
+  check-build_push_image:
+    needs: [pr-norm-branch]
+    uses: brianjbayer/actions-image-cicd/.github/workflows/build_push_image.yml@main
+    with:
+      image: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_test:${{ github.event.pull_request.head.sha }}
+    secrets:
+      registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
+      registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+  check-pull_push_image:
+    needs: [check-build_push_image, pr-norm-branch]
+    uses: brianjbayer/actions-image-cicd/.github/workflows/pull_push_image.yml@main
+    with:
+      pull_as: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_test:${{ github.event.pull_request.head.sha }}
+      push_as: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}:${{ github.event.pull_request.head.sha }}
+    secrets:
+      registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
+      registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+  check-pull_push_latest_image:
+    needs: [check-pull_push_image, pr-norm-branch]
+    uses: brianjbayer/actions-image-cicd/.github/workflows/pull_push_latest_image.yml@main
+    with:
+      image_name: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}
+      image_tag: ${{ github.event.pull_request.head.sha }}
+    secrets:
+      registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
+      registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}

--- a/.github/workflows/on_push_merge_checks.yml
+++ b/.github/workflows/on_push_merge_checks.yml
@@ -11,35 +11,45 @@ jobs:
   branch-and-last-commit:
     uses: brianjbayer/actions-image-cicd/.github/workflows/get_merged_branch_last_commit.yml@main
 
-  branch-and-last-commit-merged-info:
+  push-norm-branch:
     needs: [branch-and-last-commit]
+    uses: brianjbayer/actions-image-cicd/.github/workflows/normalize_for_image_name.yml@main
+    with:
+      raw_name: ${{ needs.branch-and-last-commit.outputs.branch }}
+
+  branch-and-last-commit-merged-info:
+    needs: [branch-and-last-commit, push-norm-branch]
     runs-on: ubuntu-latest
     env:
       BRANCH_LAST_COMMIT: ${{ needs.branch-and-last-commit.outputs.commit }}
       BRANCH: ${{ needs.branch-and-last-commit.outputs.branch }}
+      NORM_BRANCH: ${{ needs.push-norm-branch.outputs.name }}
+
     steps:
       - name: Output last commit of merged branch env var
         run: echo "BRANCH_LAST_COMMIT=[${BRANCH_LAST_COMMIT}]"
       - name: Output merged branch env var
         run: echo "BRANCH=[${BRANCH}]"
+      - name: Output normalized merged branch env var
+        run: echo "NORM_BRANCH=[${NORM_BRANCH}]"
 
 # Ensure last branch commit-tagged image exists
 # This should demonstrate impotence in the output
 # if the commit was created as part of PR job
   ensure-last-branch-commit-image:
-    needs: [branch-and-last-commit]
+    needs: [branch-and-last-commit, push-norm-branch]
     uses: brianjbayer/actions-image-cicd/.github/workflows/build_push_image.yml@main
     with:
-      image: ${{ github.repository }}_${{ needs.branch-and-last-commit.outputs.branch }}:${{ needs.branch-and-last-commit.outputs.commit }}
+      image: ${{ github.repository }}_${{ needs.push-norm-branch.outputs.name }}:${{ needs.branch-and-last-commit.outputs.commit }}
     secrets:
       registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
       registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
   promote-branch-last-commit-to-prod:
-    needs: [branch-and-last-commit, ensure-last-branch-commit-image]
+    needs: [branch-and-last-commit, ensure-last-branch-commit-image, push-norm-branch]
     uses: brianjbayer/actions-image-cicd/.github/workflows/pull_push_image.yml@main
     with:
-      pull_as: ${{ github.repository }}_${{ needs.branch-and-last-commit.outputs.branch }}:${{ needs.branch-and-last-commit.outputs.commit }}
+      pull_as: ${{ github.repository }}_${{ needs.push-norm-branch.outputs.name }}:${{ needs.branch-and-last-commit.outputs.commit }}
       push_as: ${{ github.repository }}:${{ needs.branch-and-last-commit.outputs.commit }}
     secrets:
       registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}


### PR DESCRIPTION
# What & Why
This changeset adds the normalization of the branch-based image name to support valid branch names that are not valid image names.

# Change Impact Analysis and Testing
These changes were tested in a clone of this repository then those on-PR and on-Push(Merge) workflow files were copied over the existing.  Finally a diff was done to confirm they are identical.
