### PR TITLE
Replace Deprecated set-output Commands with New Environment Variables Approach 

### DIFF
--- a/.github/workflows/get_merged_branch_last_commit.yml
+++ b/.github/workflows/get_merged_branch_last_commit.yml
@@ -26,6 +26,6 @@ jobs:
         run: echo "$(git log -n 1 --skip 1 --pretty=format:"%H")"
 
       - id: getbranch
-        run: echo "::set-output name=branch::$(git log -1 --pretty=%B | grep 'Merge pull request' | sed 's/^[^/]*\///')"
+        run: echo "branch=$(git log -1 --pretty=%B | grep 'Merge pull request' | sed 's/^[^/]*\///')" >> $GITHUB_OUTPUT
       - id: getcommit
-        run: echo "::set-output name=commit::$(git log -n 1 --skip 1 --pretty=format:"%H")"
+        run: echo "commit=$(git log -n 1 --skip 1 --pretty=format:"%H")" >> $GITHUB_OUTPUT

--- a/.github/workflows/normalize_for_image_name.yml
+++ b/.github/workflows/normalize_for_image_name.yml
@@ -31,6 +31,4 @@ jobs:
         #  2. Convert any uppercase letters to lowercase (tr '[:upper:]' '[:lower:]')
         #  3. Strip any leading and trailing spaces (xargs echo -n)
         #  4. Convert spaces to dashes (tr ' ' '-')
-        # run: echo "::set-output name=norm_name::$(echo "$RAW_NAME" | tr -cs '[:alnum:]' ' ' | tr '[:upper:]' '[:lower:]' | xargs echo -n | tr ' ' '-')"
         run: echo "norm_name=$(echo "$RAW_NAME" | tr -cs '[:alnum:]' ' ' | tr '[:upper:]' '[:lower:]' | xargs echo -n | tr ' ' '-')" >> $GITHUB_OUTPUT
-

--- a/.github/workflows/normalize_for_image_name.yml
+++ b/.github/workflows/normalize_for_image_name.yml
@@ -31,4 +31,6 @@ jobs:
         #  2. Convert any uppercase letters to lowercase (tr '[:upper:]' '[:lower:]')
         #  3. Strip any leading and trailing spaces (xargs echo -n)
         #  4. Convert spaces to dashes (tr ' ' '-')
-        run: echo "::set-output name=norm_name::$(echo "$RAW_NAME" | tr -cs '[:alnum:]' ' ' | tr '[:upper:]' '[:lower:]' | xargs echo -n | tr ' ' '-')"
+        # run: echo "::set-output name=norm_name::$(echo "$RAW_NAME" | tr -cs '[:alnum:]' ' ' | tr '[:upper:]' '[:lower:]' | xargs echo -n | tr ' ' '-')"
+        run: echo "norm_name=$(echo "$RAW_NAME" | tr -cs '[:alnum:]' ' ' | tr '[:upper:]' '[:lower:]' | xargs echo -n | tr ' ' '-')" >> $GITHUB_OUTPUT
+

--- a/.github/workflows/on_pr_checks.yml
+++ b/.github/workflows/on_pr_checks.yml
@@ -17,9 +17,7 @@ jobs:
     uses: brianjbayer/actions-image-cicd/.github/workflows/git_github_info.yml@main
 
   normalize-valid-image-name:
-    # uses: brianjbayer/actions-image-cicd/.github/workflows/normalize_for_image_name.yml@main
-    # User workflow from same commit
-    uses: ./.github/workflows/normalize_for_image_name.yml
+    uses: brianjbayer/actions-image-cicd/.github/workflows/normalize_for_image_name.yml@main
     with:
       raw_name: valid-lowercase-dashes-numbers-22
 
@@ -35,9 +33,7 @@ jobs:
         run: test "$NORM_NAME" = 'valid-lowercase-dashes-numbers-22'
 
   normalize-invalid-image-name:
-    # uses: brianjbayer/actions-image-cicd/.github/workflows/normalize_for_image_name.yml@main
-    # User workflow from same commit
-    uses: ./.github/workflows/normalize_for_image_name.yml
+    uses: brianjbayer/actions-image-cicd/.github/workflows/normalize_for_image_name.yml@main
     with:
       raw_name: "  Dependabot/bundler//nokogiri-1.13.4  "
 

--- a/.github/workflows/on_pr_checks.yml
+++ b/.github/workflows/on_pr_checks.yml
@@ -17,7 +17,9 @@ jobs:
     uses: brianjbayer/actions-image-cicd/.github/workflows/git_github_info.yml@main
 
   normalize-valid-image-name:
-    uses: brianjbayer/actions-image-cicd/.github/workflows/normalize_for_image_name.yml@main
+    # uses: brianjbayer/actions-image-cicd/.github/workflows/normalize_for_image_name.yml@main
+    # User workflow from same commit
+    uses: ./.github/workflows/normalize_for_image_name.yml
     with:
       raw_name: valid-lowercase-dashes-numbers-22
 
@@ -33,7 +35,9 @@ jobs:
         run: test "$NORM_NAME" = 'valid-lowercase-dashes-numbers-22'
 
   normalize-invalid-image-name:
-    uses: brianjbayer/actions-image-cicd/.github/workflows/normalize_for_image_name.yml@main
+    # uses: brianjbayer/actions-image-cicd/.github/workflows/normalize_for_image_name.yml@main
+    # User workflow from same commit
+    uses: ./.github/workflows/normalize_for_image_name.yml
     with:
       raw_name: "  Dependabot/bundler//nokogiri-1.13.4  "
 


### PR DESCRIPTION
# What
This changeset replaces the deprecated GitHub Actions `set-output` command with the new recommended approach of using the `$GITHUB_OUTPUT` environment variable in the `normalize_for_image_name.yml` and `get_merged_branch_last_commit.yml` workflows.

# Why
The original method of setting outputs using the `set-output` command is now deprecated per https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

# Change Impact Analysis and Testing
These changes only affect the internal outputs of the `normalize_for_image_name.yml` and `get_merged_branch_last_commit.yml` workflows.

The `normalize_for_image_name.yml` was initially tested within this project itself in the `on_pr_checks.yml` workflow by referencing this branch when using the `normalize_for_image_name.yml` reusable workflow.  This has been changed back to referencing `main`.

Both the `normalize_for_image_name.yml` and `get_merged_branch_last_commit.yml` workflows were tested under https://github.com/brianjbayer/gh-actions-test-bed/pull/38 as the only way to test the `get_merged_branch_last_commit.yml` workflow is by merging.
