### PR TITLE
Add Multi-Architecture Build and Copy (Promote) Image Workflows

### DIFF
--- a/.github/workflows/buildx_push_image.yml
+++ b/.github/workflows/buildx_push_image.yml
@@ -6,8 +6,12 @@ on:
       image:
         required: true
         type: string
+      platforms:
+        required: true
+        type: string
       buildopts:
         type: string
+
     secrets:
       registry_u:
         required: true
@@ -43,7 +47,8 @@ jobs:
         env:
           DOCKER_BUILDKIT: 1
           BUILDOPTS: ${{ inputs.buildopts }}
-        run: docker pull ${IMAGE} || (docker buildx build --no-cache ${BUILDOPTS} --push --platform linux/amd64,linux/arm64 --tag ${IMAGE} .)
+          PLATFORMS: ${{ inputs.platforms }}
+        run: docker pull ${IMAGE} || (docker buildx build --no-cache ${BUILDOPTS} --push --platform ${PLATFORMS} --tag ${IMAGE} .)
 
       - name: Logout of DockerHub Registry
         run: docker logout

--- a/.github/workflows/buildx_push_image.yml
+++ b/.github/workflows/buildx_push_image.yml
@@ -1,0 +1,49 @@
+name: Idempotent Buildx Multi Arch Push Image
+
+on:
+  workflow_call:
+    inputs:
+      image:
+        required: true
+        type: string
+      buildopts:
+        type: string
+    secrets:
+      registry_u:
+        required: true
+      registry_p:
+        required: true
+
+jobs:
+
+  pull-or-buildx-and-push-image:
+    name: Pull or Build Multi Arch and Push Image
+    runs-on: ubuntu-latest
+    env:
+      IMAGE: ${{ inputs.image }}
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Image name
+        run: echo "Image name [${IMAGE}]"
+
+      # https://github.com/docker/setup-qemu-action
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub Registry
+        run: echo ${{ secrets.registry_p }} | docker login -u ${{ secrets.registry_u }} --password-stdin
+
+      - name: If not pull image, buildx and push image
+        env:
+          DOCKER_BUILDKIT: 1
+          BUILDOPTS: ${{ inputs.buildopts }}
+        run: docker pull ${IMAGE} || (docker buildx build --no-cache ${BUILDOPTS} --push --platform linux/amd64,linux/arm64 --tag ${IMAGE} .)
+
+      - name: Logout of DockerHub Registry
+        run: docker logout

--- a/.github/workflows/copy_image.yml
+++ b/.github/workflows/copy_image.yml
@@ -1,0 +1,45 @@
+name: Idempotent Copy (Promote) Image
+
+on:
+  workflow_call:
+    inputs:
+      source_image:
+        required: true
+        type: string
+      target_image:
+        required: true
+        type: string
+    secrets:
+      registry_u:
+        required: true
+      registry_p:
+        required: true
+
+jobs:
+
+  pull-or-pull-and-push-images:
+    name: Pull or Pull and Push Images
+    runs-on: ubuntu-latest
+    env:
+      SOURCE_IMAGE: ${{ inputs.source_image }}
+      TARGET_IMAGE: ${{ inputs.target_image }}
+
+    steps:
+      - name: Install regctl registry tool
+        run: |
+          curl -fsSL "https://github.com/regclient/regclient/releases/latest/download/regctl-linux-amd64" >regctl
+
+      - name: Make regctl executable
+        run: chmod 755 regctl
+
+      - name: Testing ls directory
+        run: ls -al
+
+      - name: Login to DockerHub Registry
+        run: echo ${{ secrets.registry_p }} | docker login -u ${{ secrets.registry_u }} --password-stdin
+
+      - name: If the target image does not exist, copy source image to target image
+        run: docker pull ${TARGET_IMAGE} || ./regctl image copy ${SOURCE_IMAGE} ${TARGET_IMAGE}
+
+      - name: Logout of DockerHub Registry
+        run: docker logout

--- a/.github/workflows/copy_image_to_latest.yml
+++ b/.github/workflows/copy_image_to_latest.yml
@@ -1,12 +1,12 @@
-name: Idempotent Copy (Promote) Image
+name: Copy Image To Latest
 
 on:
   workflow_call:
     inputs:
-      source_image:
+      image_name:
         required: true
         type: string
-      target_image:
+      image_tag:
         required: true
         type: string
     secrets:
@@ -17,12 +17,12 @@ on:
 
 jobs:
 
-  pull-or-copy-images:
-    name: Pull or Copy Image
+  copy-image-to-latest:
+    name: Copy Image:Tag to Image:latest
     runs-on: ubuntu-latest
     env:
-      SOURCE_IMAGE: ${{ inputs.source_image }}
-      TARGET_IMAGE: ${{ inputs.target_image }}
+      IMAGE_NAME: ${{ inputs.image_name }}
+      IMAGE_TAG: ${{ inputs.image_tag }}
 
     steps:
       - name: Install regctl registry tool
@@ -35,8 +35,8 @@ jobs:
       - name: Login to DockerHub Registry
         run: echo ${{ secrets.registry_p }} | docker login -u ${{ secrets.registry_u }} --password-stdin
 
-      - name: If the target image does not exist, copy source image to target image
-        run: docker pull ${TARGET_IMAGE} || ./regctl image copy ${SOURCE_IMAGE} ${TARGET_IMAGE}
+      - name: Copy image:tag to latest tag
+        run: ./regctl image copy ${IMAGE_NAME}:${IMAGE_TAG} ${IMAGE_NAME}:latest
 
       - name: Logout of DockerHub Registry
         run: docker logout

--- a/.github/workflows/on_pr_checks.yml
+++ b/.github/workflows/on_pr_checks.yml
@@ -53,9 +53,11 @@ jobs:
     with:
       raw_name: ${{ github.head_ref }}
 
-  check-build_push_image:
+  # TODO: Testing buildx
+  check-buildx_push_image:
     needs: [pr-norm-branch]
-    uses: brianjbayer/actions-image-cicd/.github/workflows/build_push_image.yml@main
+    # TODO: Restore to main branch
+    uses: brianjbayer/actions-image-cicd/.github/workflows/buildx_push_image.yml@add-multi-arch-buildx
     with:
       image: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_test:${{ github.event.pull_request.head.sha }}
     secrets:
@@ -63,7 +65,7 @@ jobs:
       registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
   check-pull_push_image:
-    needs: [check-build_push_image, pr-norm-branch]
+    needs: [check-buildx_push_image, pr-norm-branch]
     uses: brianjbayer/actions-image-cicd/.github/workflows/pull_push_image.yml@main
     with:
       pull_as: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_test:${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/on_pr_checks.yml
+++ b/.github/workflows/on_pr_checks.yml
@@ -57,7 +57,7 @@ jobs:
     needs: [pr-norm-branch]
     uses: brianjbayer/actions-image-cicd/.github/workflows/build_push_image.yml@main
     with:
-      image: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_test_ci_arch:${{ github.event.pull_request.head.sha }}
+      image: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_test_push:${{ github.event.pull_request.head.sha }}
     secrets:
       registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
       registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
@@ -79,8 +79,8 @@ jobs:
     needs: [check-build_push_image, pr-norm-branch]
     uses: brianjbayer/actions-image-cicd/.github/workflows/pull_push_image.yml@main
     with:
-      pull_as: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_test_ci_arch:${{ github.event.pull_request.head.sha }}
-      push_as: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_ci_arch:${{ github.event.pull_request.head.sha }}
+      pull_as: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_test_push:${{ github.event.pull_request.head.sha }}
+      push_as: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_push:${{ github.event.pull_request.head.sha }}
     secrets:
       registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
       registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
@@ -98,6 +98,16 @@ jobs:
   check-pull_push_latest_image:
     needs: [check-pull_push_image, pr-norm-branch]
     uses: brianjbayer/actions-image-cicd/.github/workflows/pull_push_latest_image.yml@main
+    with:
+      image_name: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_push
+      image_tag: ${{ github.event.pull_request.head.sha }}
+    secrets:
+      registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
+      registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+  check-copy_image_to_latest:
+    needs: [check-copy_image, pr-norm-branch]
+    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image_yo_latest.yml@add-multi-arch-buildx
     with:
       image_name: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}
       image_tag: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/on_pr_checks.yml
+++ b/.github/workflows/on_pr_checks.yml
@@ -107,7 +107,7 @@ jobs:
 
   check-copy_image_to_latest:
     needs: [check-copy_image, pr-norm-branch]
-    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image_yo_latest.yml@add-multi-arch-buildx
+    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image_to_latest.yml@add-multi-arch-buildx
     with:
       image_name: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}
       image_tag: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/on_pr_checks.yml
+++ b/.github/workflows/on_pr_checks.yml
@@ -53,13 +53,24 @@ jobs:
     with:
       raw_name: ${{ github.head_ref }}
 
-  # TODO: Testing buildx
+  check-build_push_image:
+    needs: [pr-norm-branch]
+    uses: brianjbayer/actions-image-cicd/.github/workflows/build_push_image.yml@main
+    with:
+      image: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_test_ci_arch:${{ github.event.pull_request.head.sha }}
+    secrets:
+      registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
+      registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+  # Multi Architecture Builds (assumed default)
+  # TODO: TESTING
   check-buildx_push_image:
     needs: [pr-norm-branch]
     # TODO: Restore to main branch
     uses: brianjbayer/actions-image-cicd/.github/workflows/buildx_push_image.yml@add-multi-arch-buildx
     with:
       image: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_test:${{ github.event.pull_request.head.sha }}
+      platforms: "linux/amd64,linux/arm64"
     secrets:
       registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
       registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}

--- a/.github/workflows/on_pr_checks.yml
+++ b/.github/workflows/on_pr_checks.yml
@@ -63,7 +63,6 @@ jobs:
       registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
   # Multi Architecture Builds (assumed default)
-  # TODO: TESTING
   check-buildx_push_image:
     needs: [pr-norm-branch]
     # TODO: Restore to main branch

--- a/.github/workflows/on_pr_checks.yml
+++ b/.github/workflows/on_pr_checks.yml
@@ -76,11 +76,21 @@ jobs:
       registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
   check-pull_push_image:
-    needs: [check-buildx_push_image, pr-norm-branch]
+    needs: [check-build_push_image, pr-norm-branch]
     uses: brianjbayer/actions-image-cicd/.github/workflows/pull_push_image.yml@main
     with:
-      pull_as: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_test:${{ github.event.pull_request.head.sha }}
-      push_as: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}:${{ github.event.pull_request.head.sha }}
+      pull_as: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_test_ci_arch:${{ github.event.pull_request.head.sha }}
+      push_as: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_ci_arch:${{ github.event.pull_request.head.sha }}
+    secrets:
+      registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
+      registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+  check-copy_image:
+    needs: [check-buildx_push_image, pr-norm-branch]
+    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image.yml@add-multi-arch-buildx
+    with:
+      source_image: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_test:${{ github.event.pull_request.head.sha }}
+      target_image: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}:${{ github.event.pull_request.head.sha }}
     secrets:
       registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
       registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}

--- a/.github/workflows/on_push_merge_checks.yml
+++ b/.github/workflows/on_push_merge_checks.yml
@@ -36,28 +36,58 @@ jobs:
 # Ensure last branch commit-tagged image exists
 # This should demonstrate impotence in the output
 # if the commit was created as part of PR job
-  ensure-last-branch-commit-image:
+  ensure-last-branch-build-push-commit-image:
     needs: [branch-and-last-commit, push-norm-branch]
     uses: brianjbayer/actions-image-cicd/.github/workflows/build_push_image.yml@main
     with:
-      image: ${{ github.repository }}_${{ needs.push-norm-branch.outputs.name }}:${{ needs.branch-and-last-commit.outputs.commit }}
+      image: ${{ github.repository }}_${{ needs.push-norm-branch.outputs.name }}_push:${{ needs.branch-and-last-commit.outputs.commit }}
     secrets:
       registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
       registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
-  promote-branch-last-commit-to-prod:
-    needs: [branch-and-last-commit, ensure-last-branch-commit-image, push-norm-branch]
+  ensure-last-branch-buildx-push-commit-image:
+    needs: [branch-and-last-commit, push-norm-branch]
+    uses: brianjbayer/actions-image-cicd/.github/workflows/buildx_push_image.yml@add-multi-arch-buildx
+    with:
+      image: ${{ github.repository }}_${{ needs.push-norm-branch.outputs.name }}:${{ needs.branch-and-last-commit.outputs.commit }}
+      platforms: "linux/amd64,linux/arm64"
+    secrets:
+      registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
+      registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+  pull-push-image-branch-last-commit-to-prod:
+    needs: [branch-and-last-commit, ensure-last-branch-build-push-commit-image, push-norm-branch]
     uses: brianjbayer/actions-image-cicd/.github/workflows/pull_push_image.yml@main
     with:
-      pull_as: ${{ github.repository }}_${{ needs.push-norm-branch.outputs.name }}:${{ needs.branch-and-last-commit.outputs.commit }}
-      push_as: ${{ github.repository }}:${{ needs.branch-and-last-commit.outputs.commit }}
+      pull_as: ${{ github.repository }}_${{ needs.push-norm-branch.outputs.name }}_push:${{ needs.branch-and-last-commit.outputs.commit }}
+      push_as: ${{ github.repository }}_push:${{ needs.branch-and-last-commit.outputs.commit }}
     secrets:
       registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
       registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
-  promote-branch-last-commit-to-prod-latest:
-    needs: [branch-and-last-commit, promote-branch-last-commit-to-prod]
+  copy-image-branch-last-commit-to-prod:
+    needs: [branch-and-last-commit, ensure-last-branch-buildx-push-commit-image, push-norm-branch]
+    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image.yml@add-multi-arch-buildx
+    with:
+      source_image: ${{ github.repository }}_${{ needs.push-norm-branch.outputs.name }}:${{ needs.branch-and-last-commit.outputs.commit }}
+      target_image: ${{ github.repository }}:${{ needs.branch-and-last-commit.outputs.commit }}
+    secrets:
+      registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
+      registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+  pull-push-image-branch-last-commit-to-prod-latest:
+    needs: [branch-and-last-commit, pull-push-image-branch-last-commit-to-prod]
     uses: brianjbayer/actions-image-cicd/.github/workflows/pull_push_latest_image.yml@main
+    with:
+      image_name: ${{ github.repository }}_push
+      image_tag: ${{ needs.branch-and-last-commit.outputs.commit }}
+    secrets:
+      registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
+      registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+  copy-image-branch-last-commit-to-prod-latest:
+    needs: [branch-and-last-commit, copy-image-branch-last-commit-to-prod]
+    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image_to_latest_image.yml@main
     with:
       image_name: ${{ github.repository }}
       image_tag: ${{ needs.branch-and-last-commit.outputs.commit }}


### PR DESCRIPTION
# What
This changeset adds new reusable workflows to support multi-architecture images (e.g. `linux/amd64`, `linux/arm64`):
1. `.github/workflows/buildx_push_image.yml` - this builds the specified platforms (architectures)
3. `.github/workflows/copy_image.yml` - this installs and uses `regctl` to copy image with all platforms
4. `.github/workflows/copy_image_to_latest.yml` - this installs and uses `regctl` to copy image with all platforms to `latest` tag

The two new copy workflows install and use the
`[regclient](https://github.com/regclient/regclient)`
container registry command line tool.  Other than the complicated task of individually pushing and tagging the different platform images and the trying to create manifest for them, this approach seemed the least worst option and probably the correct approach of doing this at the container registry level.

New checks were also added to this project's CI workflows.

# Why
These additional workflows will now provide support for multi-architecture images

# Change Impact Analysis and Testing
This changeset is additive.

- [x] Existing functionality (no regressions) vetted by CI Checks
- [x] All new workflows vetted by PR CI checks (verified new checks)
- [x] New workflows used in PR and merge vetted by brianjbayer/SampleCSharpXunitSelenium#10
- [x] New PR Checks vetted
- [ ] New merge checks vetted - won't be testable (requires the merge)

# TODO

- [ ] Fix any merge bugs
- [ ] Update branch to main for new workflows in CI checks
