### PR TITLE
Use correct copy latest name

### DIFF
--- a/.github/workflows/on_push_merge_checks.yml
+++ b/.github/workflows/on_push_merge_checks.yml
@@ -87,7 +87,7 @@ jobs:
 
   copy-image-branch-last-commit-to-prod-latest:
     needs: [branch-and-last-commit, copy-image-branch-last-commit-to-prod]
-    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image_to_latest_image.yml@main
+    uses: uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image_to_latest.yml@add-multi-arch-buildx
     with:
       image_name: ${{ github.repository }}
       image_tag: ${{ needs.branch-and-last-commit.outputs.commit }}


### PR DESCRIPTION
# What
This changeset attempts to fix the on merge workflows error
```
 Check failure on line 90 in .github/workflows/on_push_merge_checks.yml

GitHub Actions
/ .github/workflows/on_push_merge_checks.yml
Invalid workflow file
error parsing called workflow
".github/workflows/on_push_merge_checks.yml"
-> "brianjbayer/actions-image-cicd/.github/workflows/copy_image_to_latest_image.yml@main"
: failed to fetch workflow: workflow was not found.
```

The wrong workflow name was being used causing the parse error.