### PR TITLE
Add multi-architecture (platform) image support officially

### DIFF
--- a/.github/workflows/on_pr_checks.yml
+++ b/.github/workflows/on_pr_checks.yml
@@ -65,8 +65,7 @@ jobs:
   # Multi Architecture Builds (assumed default)
   check-buildx_push_image:
     needs: [pr-norm-branch]
-    # TODO: Restore to main branch
-    uses: brianjbayer/actions-image-cicd/.github/workflows/buildx_push_image.yml@add-multi-arch-buildx
+    uses: brianjbayer/actions-image-cicd/.github/workflows/buildx_push_image.yml@main
     with:
       image: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_test:${{ github.event.pull_request.head.sha }}
       platforms: "linux/amd64,linux/arm64"
@@ -86,7 +85,7 @@ jobs:
 
   check-copy_image:
     needs: [check-buildx_push_image, pr-norm-branch]
-    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image.yml@add-multi-arch-buildx
+    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image.yml@main
     with:
       source_image: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_test:${{ github.event.pull_request.head.sha }}
       target_image: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}:${{ github.event.pull_request.head.sha }}
@@ -106,7 +105,7 @@ jobs:
 
   check-copy_image_to_latest:
     needs: [check-copy_image, pr-norm-branch]
-    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image_to_latest.yml@add-multi-arch-buildx
+    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image_to_latest.yml@main
     with:
       image_name: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}
       image_tag: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/on_push_merge_checks.yml
+++ b/.github/workflows/on_push_merge_checks.yml
@@ -47,7 +47,7 @@ jobs:
 
   ensure-last-branch-buildx-push-commit-image:
     needs: [branch-and-last-commit, push-norm-branch]
-    uses: brianjbayer/actions-image-cicd/.github/workflows/buildx_push_image.yml@add-multi-arch-buildx
+    uses: brianjbayer/actions-image-cicd/.github/workflows/buildx_push_image.yml@main
     with:
       image: ${{ github.repository }}_${{ needs.push-norm-branch.outputs.name }}:${{ needs.branch-and-last-commit.outputs.commit }}
       platforms: "linux/amd64,linux/arm64"
@@ -67,7 +67,7 @@ jobs:
 
   copy-image-branch-last-commit-to-prod:
     needs: [branch-and-last-commit, ensure-last-branch-buildx-push-commit-image, push-norm-branch]
-    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image.yml@add-multi-arch-buildx
+    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image.yml@main
     with:
       source_image: ${{ github.repository }}_${{ needs.push-norm-branch.outputs.name }}:${{ needs.branch-and-last-commit.outputs.commit }}
       target_image: ${{ github.repository }}:${{ needs.branch-and-last-commit.outputs.commit }}
@@ -87,7 +87,7 @@ jobs:
 
   copy-image-branch-last-commit-to-prod-latest:
     needs: [branch-and-last-commit, copy-image-branch-last-commit-to-prod]
-    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image_to_latest.yml@add-multi-arch-buildx
+    uses: brianjbayer/actions-image-cicd/.github/workflows/copy_image_to_latest.yml@main
     with:
       image_name: ${{ github.repository }}
       image_tag: ${{ needs.branch-and-last-commit.outputs.commit }}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ These reusable actions are primarily designed to be used
 in another repository's Continuous Integration/Continuous Deployment
 (CI/CD) where the image is the deployable artifact.
 
+These reusable actions support both single architecture (platform)
+and multi-architecture images (although the specific actions used differ),
+
 See [GitHub's Documentation on Reusable Actions](https://docs.github.com/en/actions/using-workflows/reusing-workflows)
 and the gist [The Basics of GitHub Actions Reusable Workflows](https://gist.github.com/brianjbayer/a1e73789fa26deda500c829d1b4d0d88).
 
@@ -61,7 +64,11 @@ With this intended CI/CD, there are two basic GitHub Actions workflows...
        ```
        .github/workflows/build_push_image.yml@main
        ```
-    2. Pull and perform vetting (e.g. linting, security scans, 
+       or build and push **multi-architecture image**:
+       ```
+       .github/workflows/buildx_push_image.yml@main
+       ```
+    2. Pull and perform vetting (e.g. linting, security scans,
        unit tests, end-to-end tests etc) on pushed unvetted potential
        release candidate image
     3. If all vetting checks passed, promote the unvetted potential
@@ -69,6 +76,10 @@ With this intended CI/CD, there are two basic GitHub Actions workflows...
        using:
        ```
        .github/workflows/pull_push_image.yml@main
+       ```
+       or promote by copying **multi-architecture image**:
+       ```
+       .github/workflows/copy_image.yml@main
        ```
 
   * **On Push to main (merge)...**
@@ -81,11 +92,27 @@ With this intended CI/CD, there are two basic GitHub Actions workflows...
        ```
        .github/workflows/pull_push_image.yml@main
        ```
+       or promote by copying **multi-architecture image**:
+       ```
+       .github/workflows/copy_image.yml@main
+       ```
     3. Optionally tag the just promoted production image as latest
        using:
        ```
        .github/workflows/pull_push_latest_image.yml@main
        ```
+       or tag by copying **multi-architecture image** to latest:
+       ```
+       .github/workflows/copy_image_to_latest.yml@main
+       ```
+
+## Dependencies
+The multi-architecture `copy_image*` workflows use and depend upon the awesome
+[`regclient`](https://github.com/regclient/regclient)
+command line tool which allows copying of all image architectures
+at the container registry (i.e. DockerHub) level instead of pulling,
+tagging, and pushing.
+
 
 For more on image-based CI/CD, see the gist
 [An Image-Based Continuous Integration / Continuous Deployment Model](https://gist.github.com/brianjbayer/e5e9f07e0923d8d097d7b03803ea837b).


### PR DESCRIPTION
# What
This changeset officially adds multi-architecture image support by...
- updating these workflows in CI checks to `main` branch
- updating README

# Change Impact Analysis and Testing

- [x] Readme updates inspected on branch
- [x] PR CI checks pass
- [ ] Merge CO checks pass (only on merge)

