### PR TITLE
Dash not underscore for image name separator

### DIFF
--- a/.github/workflows/image_names.yml
+++ b/.github/workflows/image_names.yml
@@ -72,10 +72,10 @@ jobs:
 
     steps:
       - id: dev
-        run: echo "dev_name=${{ inputs.image_base_name }}${ADD_BRANCH}_dev:${{inputs.tag}}" >> $GITHUB_OUTPUT
+        run: echo "dev_name=${{ inputs.image_base_name }}${ADD_BRANCH}-dev:${{inputs.tag}}" >> $GITHUB_OUTPUT
 
       - id: unvetted
-        run: echo "unvetted_name=${{ inputs.image_base_name }}${ADD_BRANCH}_unvetted:${{inputs.tag}}" >> $GITHUB_OUTPUT
+        run: echo "unvetted_name=${{ inputs.image_base_name }}${ADD_BRANCH}-unvetted:${{inputs.tag}}" >> $GITHUB_OUTPUT
 
       - id: vetted
         run: echo "vetted_name=${{ inputs.image_base_name }}${ADD_BRANCH}:${{inputs.tag}}" >> $GITHUB_OUTPUT

--- a/.github/workflows/on_pr_checks.yml
+++ b/.github/workflows/on_pr_checks.yml
@@ -65,10 +65,10 @@ jobs:
           echo "Unvetted Image Name : ${UNVETTED_IMAGE}"
           echo "Vetted Image Name   : ${VETTED_IMAGE}"
       - name: Verify Dev Image Name
-        run: test "$DEV_IMAGE" = "${{ github.repository }}_dev:${{ github.event.pull_request.head.sha }}"
+        run: test "$DEV_IMAGE" = "${{ github.repository }}-dev:${{ github.event.pull_request.head.sha }}"
       - name: Verify Unvetted Image Name
         if: ${{ success() || failure() }}
-        run: test "$UNVETTED_IMAGE" = "${{ github.repository }}_unvetted:${{ github.event.pull_request.head.sha }}"
+        run: test "$UNVETTED_IMAGE" = "${{ github.repository }}-unvetted:${{ github.event.pull_request.head.sha }}"
       - name: Verify Vetted Image Name
         if: ${{ success() || failure() }}
         run: test "$VETTED_IMAGE" = "${{ github.repository }}:${{ github.event.pull_request.head.sha }}"
@@ -94,10 +94,10 @@ jobs:
           echo "Unvetted Image Name : ${UNVETTED_IMAGE}"
           echo "Vetted Image Name   : ${VETTED_IMAGE}"
       - name: Verify Dev Image Name
-        run: test "$DEV_IMAGE" = "${{ github.repository }}_${{ github.head_ref }}_dev:${{ github.event.pull_request.head.sha }}"
+        run: test "$DEV_IMAGE" = "${{ github.repository }}_${{ github.head_ref }}-dev:${{ github.event.pull_request.head.sha }}"
       - name: Verify Unvetted Image Name
         if: ${{ success() || failure() }}
-        run: test "$UNVETTED_IMAGE" = "${{ github.repository }}_${{ github.head_ref }}_unvetted:${{ github.event.pull_request.head.sha }}"
+        run: test "$UNVETTED_IMAGE" = "${{ github.repository }}_${{ github.head_ref }}-unvetted:${{ github.event.pull_request.head.sha }}"
       - name: Verify Vetted Image Name
         if: ${{ success() || failure() }}
         run: test "$VETTED_IMAGE" = "${{ github.repository }}_${{ github.head_ref }}:${{ github.event.pull_request.head.sha }}"
@@ -125,11 +125,10 @@ jobs:
           echo "Unvetted Image Name : ${UNVETTED_IMAGE}"
           echo "Vetted Image Name   : ${VETTED_IMAGE}"
       - name: Verify Dev Image Name
-      # brianjbayer/actions-image-cicd_my-branch_dev:7e149a2ab17591102f05f7815a1d94ea8cc2e6d6
-        run: test "$DEV_IMAGE" = "${{ github.repository }}_${NORM_BRANCH}_dev:${{ github.event.pull_request.head.sha }}"
+        run: test "$DEV_IMAGE" = "${{ github.repository }}_${NORM_BRANCH}-dev:${{ github.event.pull_request.head.sha }}"
       - name: Verify Unvetted Image Name
         if: ${{ success() || failure() }}
-        run: test "$UNVETTED_IMAGE" = "${{ github.repository }}_${NORM_BRANCH}_unvetted:${{ github.event.pull_request.head.sha }}"
+        run: test "$UNVETTED_IMAGE" = "${{ github.repository }}_${NORM_BRANCH}-unvetted:${{ github.event.pull_request.head.sha }}"
       - name: Verify Vetted Image Name
         if: ${{ success() || failure() }}
         run: test "$VETTED_IMAGE" = "${{ github.repository }}_${NORM_BRANCH}:${{ github.event.pull_request.head.sha }}"
@@ -142,7 +141,6 @@ jobs:
     needs: pr-image-names-with-branch
     uses: ./.github/workflows/buildx_push_image.yml
     with:
-      # image: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_test:${{ github.event.pull_request.head.sha }}
       image: ${{ needs.pr-image-names-with-branch.outputs.unvetted_image }}
       platforms: "linux/amd64,linux/arm64"
     secrets:


### PR DESCRIPTION
This rectifies inadvertently using an underscore instead of the existing standard of a dash for the image name suffix (e.g. `-dev`) 