### PR TITLE
Version v0.2.2: Add Image Name Annotations to Copy/Promote Image Workflow

### DIFF
--- a/.github/workflows/copy_image.yml
+++ b/.github/workflows/copy_image.yml
@@ -48,3 +48,6 @@ jobs:
 
       - name: Logout of DockerHub Registry
         run: docker logout
+
+      - name: Annotate copied image
+        run: echo "::notice::Copied image [${{ inputs.source_image }}] -> [${{ inputs.target_image }}]"

--- a/.github/workflows/copy_image_to_latest.yml
+++ b/.github/workflows/copy_image_to_latest.yml
@@ -50,7 +50,7 @@ jobs:
     with:
       runner: ${{ inputs.runner }}
       source_image: ${{ inputs.image }}
-      target_image: ${{ needs.strip-tag-from-image.outputs.image_name_only }}
+      target_image: "${{ needs.strip-tag-from-image.outputs.image_name_only }}:latest"
     secrets:
       registry_u: ${{ secrets.registry_u }}
       registry_p: ${{ secrets.registry_p }}


### PR DESCRIPTION
# What
This backwards-compatible changeset adds an annotation to the Checks Summary that contains the source and target image names.

```
[Promote Vetted Deployment Image / Copy Image](https://github.com/brianjbayer/gh-actions-test-bed/actions/runs/11419910801/job/31775336092#step:6:8)
Copied image [***/gh-actions-test-bed_more-develop-v022-unvetted:7c3aa9359fc6401f771174943322ac2a4d32ae6e] -> [***/gh-actions-test-bed_more-develop-v022:7c3aa9359fc6401f771174943322ac2a4d32ae6e]
```

And for `copy_image_to_latest`...
```
[Promote Latest Development Image / Copy Image:Tag to Image:latest / Copy Image](https://github.com/brianjbayer/gh-actions-test-bed/actions/runs/11420096893/job/31775429397#step:6:8)
Copied image [***/gh-actions-test-bed-dev:7c3aa9359fc6401f771174943322ac2a4d32ae6e] -> [***/gh-actions-test-bed-dev:latest]
```

In addition the tag is set explicitly to `latest` in the `copy_image_to_latest` Reusable Workflow

# Why
This provides more transparency and image name of promoted images right in the Checks Summary

# Change Impact Analysis and Testing
Verified both PR and Merge Checks using `gh-actions-test-bed`.
