### PR TITLE
Use Preview ubuntu-24.04-arm Runner For Parallel Node Multiplatform Image Builds (v0.2.3)

### DIFF
--- a/.github/workflows/buildx_amd_arm_image.yml
+++ b/.github/workflows/buildx_amd_arm_image.yml
@@ -1,0 +1,98 @@
+name: Idempotent Buildx amd64/arm4 Multiplatform Image
+
+on:
+  workflow_call:
+
+    secrets:
+      registry_u:
+        description: The username for the docker login
+        required: true
+      registry_p:
+        description: The password (PAT) for the docker login
+        required: true
+
+    inputs:
+      image:
+        description: The name of the image to build and push
+        required: true
+        type: string
+      buildopts:
+        description: Optional docker buildx options
+        type: string
+      runner_general:
+        description: "The type of runner for the general jobs in workflow (Default: ubuntu-24.04-arm)"
+        required: false
+        type: string
+        default: ubuntu-24.04-arm
+      runner_amd64:
+        description: "The type of linux/amd64 runner for this workflow (Default: ubuntu-latest)"
+        required: false
+        type: string
+        default: ubuntu-latest
+      runner_arm64:
+        description: "The type of linux/arm64 runner for this workflow (Default: ubuntu-24.04-arm)"
+        required: false
+        type: string
+        default: ubuntu-24.04-arm
+
+jobs:
+
+  buildx-and-push-image:
+    name: Build and Push Platform Image
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - name: amd64
+            runner: ${{ inputs.runner_amd64 }}
+          - name: arm64
+            runner: ${{ inputs.runner_arm64 }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Image name
+        run: echo "Image name [${{ inputs.image }}-${{ matrix.platform.name }}]"
+
+      - name: Set up Docker buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub registry
+        run: echo ${{ secrets.registry_p }} | docker login -u ${{ secrets.registry_u }} --password-stdin
+
+      - name: Buildx and push image
+        env:
+          DOCKER_BUILDKIT: 1
+          BUILDOPTS: ${{ inputs.buildopts }}
+        run: |
+          docker pull ${{ inputs.image }}-${{ matrix.platform.name }} \
+          || docker buildx build \
+            --no-cache ${BUILDOPTS} \
+            --push --platform linux/${{ matrix.platform.name }} \
+            --tag ${{ inputs.image }}-${{ matrix.platform.name }} \
+            .
+
+      - name: Logout of DockerHub registry
+        run: docker logout
+
+  combine-images:
+    name: Create Multiplatform Image
+    runs-on: ${{ inputs.runner_general }}
+    needs: buildx-and-push-image
+    env:
+      IMAGE: ${{ inputs.image }}
+
+    steps:
+      - name: Login to DockerHub registry
+        run: echo ${{ secrets.registry_p }} | docker login -u ${{ secrets.registry_u }} --password-stdin
+
+      - name: Create and push multiplatform image
+        run: |
+          docker pull ${IMAGE} || docker buildx imagetools create -t ${IMAGE} ${IMAGE}-amd64 ${IMAGE}-arm64
+
+      - name: Logout of DockerHub registry
+        run: docker logout
+
+      - name: Annotate image name
+        run: echo "::notice::Built and pushed multiplatform image [${IMAGE}]"

--- a/.github/workflows/on_pr_checks.yml
+++ b/.github/workflows/on_pr_checks.yml
@@ -136,13 +136,12 @@ jobs:
 
   # --- Build/Push Multi-platform Image ---
 
-  buildx_push_image:
-    name: Build (Multi-platform) Image
+  buildx_push_amd_arm_image:
+    name: Build Multiplatform(amd/arm) Image
     needs: pr-image-names-with-branch
-    uses: ./.github/workflows/buildx_push_image.yml
+    uses: ./.github/workflows/buildx_amd_arm_image.yml
     with:
       image: ${{ needs.pr-image-names-with-branch.outputs.unvetted_image }}
-      platforms: "linux/amd64,linux/arm64"
     secrets:
       registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
       registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
@@ -153,7 +152,7 @@ jobs:
     name: Promote (Copy) Multi-platform) Image
     needs:
       - pr-image-names-with-branch
-      - buildx_push_image
+      - buildx_push_amd_arm_image
     uses: ./.github/workflows/copy_image.yml
     with:
       source_image: ${{ needs.pr-image-names-with-branch.outputs.unvetted_image }}


### PR DESCRIPTION
# What & Why
This changeset adds new Reusable Workflow `buildx_amd_arm_image` for building a `linux/amd64` and `linux/arm64` multiplatform image using separate specifiable amd64 and arm64 runners.  Two separate platform specific images are built in parallel and their manifests are combined to make a single multiplatform image.

:sparkles: This new parallel workflow reduces build times in the related testing PR from 28 minutes to less than 4 an **86% reduction** in build time.

# Change Impact Analysis and Testing
This changeset is purely additive with the addition of the new workflow file.  The only modification to existing files is the change to use this new workflow in this project's PR Checks which exercise the reusable workflows.  Thus the PR Checks verifies the new workflow.

The `linux/amd64` variant is used by the PR Checks.  The `linux/arm64` must be (locally) run on an `arm64` host to verify.

This changeset was tested with related PR brianjbayer/sample-login-capybara-rspec#127 to verify and benchmark with an actual application.

- [x] Successful PR Checks using the new workflow and verification of the workflow output verifies this new workflow
  - [x] Rerun of PR Checks and new workflow and verification of the workflow output verifies idempotence of new workflow (will not rebuild built image)
- [x] Successful PR Checks using the new workflow and verification of the workflow output on related PR verifies this new workflow for a typical project
- [x] Local run of the new workflow produced image from related PR on `arm64` (Apple Silicon) verifies multiplatform image 
  - [x] `uname -a` in image shows `aarch64`
