### PR TITLE
Add a Detect Changed Files (Using Git) Reusable Workflow

### DIFF
--- a/.github/workflows/git_detect_changed_files.yml
+++ b/.github/workflows/git_detect_changed_files.yml
@@ -1,0 +1,94 @@
+name: Detect Changed Files Using Git
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        description: "The type of runner for this workflow (Default: ubuntu-latest)"
+        required: false
+        type: string
+        default: ubuntu-latest
+      file_pattern:
+        description: "The file pattern (regex) to check for changes"
+        required: true
+        type: string
+      base_commit:
+        description: "The base commit against which to check for changes"
+        required: false
+        type: string
+      target_commit:
+        description: "The target (e.g. latest)commit to compare against the base commit"
+        required: false
+        type: string
+
+    outputs:
+      any_changed:
+        description: Returns 'true' if any files matching the pattern have changed; else 'false'
+        value: ${{ jobs.git-detect-changed-files.outputs.any_changed }}
+
+jobs:
+  git-detect-changed-files:
+    name: Detect Changed Files Using Git
+    runs-on: ${{ inputs.runner }}
+    outputs:
+      any_changed: ${{ steps.detect-changed-files.outputs.any_changed }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Git log
+        run: git log
+
+      - name: Determine target commit
+        id: get-target-commit
+        run: |
+          if [ -n "${{ inputs.target_commit }}" ]; then
+            echo "Target commit from input [${{ inputs.target_commit }}]"
+            echo "target_commit=${{ inputs.target_commit }}" >> $GITHUB_OUTPUT
+          elif [ -n "${{ github.event.pull_request.head.sha }}" ]; then
+            echo "Target (latest) commit from PR context [${{ github.event.pull_request.head.sha }}]"
+            echo "target_commit=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+          else
+            current_head=$(git log -1 --pretty=format:"%H")
+            echo "Target (latest) commit from HEAD [${current_head}]"
+            echo "target_commit=${current_head}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Determine base commit
+        id: get-base-commit
+        run: |
+          if [ -n "${{ inputs.base_commit }}" ]; then
+            echo "Base commit from input [${{ inputs.base_commit }}]"
+            echo "base_commit=${{ inputs.base_commit }}" >> $GITHUB_OUTPUT
+          elif [ -n "${{ github.event.pull_request.base.sha }}" ]; then
+            echo "Base commit from PR context [${{ github.event.pull_request.base.sha }}]"
+            echo "base_commit=${{ github.event.pull_request.base.sha }}" >> $GITHUB_OUTPUT
+          else
+            previous_head=$(git rev-parse HEAD^)
+            echo "Base commit from HEAD [${previous_head}]"
+            echo "base_commit=${previous_head}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Detect changed files
+        id: detect-changed-files
+        run: |
+          echo "Detecting changed files between [${{ steps.get-base-commit.outputs.base_commit }}] and [${{ steps.get-target-commit.outputs.target_commit }}]"
+          # Allow for no matches (command fail)
+          changed_files=$(git diff --name-only ${{ steps.get-base-commit.outputs.base_commit }}...${{ steps.get-target-commit.outputs.target_commit }} | grep -E "${{ inputs.file_pattern }}" || :)
+          if [ -n "$changed_files" ]; then
+            echo "any_changed=true" >> $GITHUB_OUTPUT
+            echo "Changed files:"
+            echo "$changed_files"
+          else
+            echo "any_changed=false" >> $GITHUB_OUTPUT
+            echo "No changed files detected for the specified pattern"
+          fi
+
+      - name: Outputs
+        run: |
+          echo "any_changed [${{ steps.detect-changed-files.outputs.any_changed }}]"
+          echo "target_commit [${{ steps.get-target-commit.outputs.target_commit }}]"
+          echo "base_commit [${{ steps.get-base-commit.outputs.base_commit }}]"

--- a/.github/workflows/on_pr_checks.yml
+++ b/.github/workflows/on_pr_checks.yml
@@ -7,8 +7,13 @@ on:
 
 jobs:
 
+    # --- Git and GitHub Info ---
+
   check-git_github_info:
+    name: Check Git and GitHub Info
     uses: ./.github/workflows/git_github_info.yml
+
+  # --- Detect Changed Files ---
 
   detect-changed-files:
     name: Detect Changed Files Using Git
@@ -32,11 +37,13 @@ jobs:
   # --- Image Name Normalizer ---
 
   normalize-valid-image-name:
+    name: Normalize Valid Image Name
     uses: ./.github/workflows/normalize_for_image_name.yml
     with:
       raw_name: valid-lowercase-dashes-numbers-22
 
   check-valid-normalize_for_image_name:
+    name: Verify Normalize Valid Image Name
     needs: [normalize-valid-image-name]
     runs-on: ubuntu-latest
     env:
@@ -48,11 +55,13 @@ jobs:
         run: test "$NORM_NAME" = 'valid-lowercase-dashes-numbers-22'
 
   normalize-invalid-image-name:
+    name: Normalize Invalid Image Name
     uses: ./.github/workflows/normalize_for_image_name.yml
     with:
       raw_name: "  Dependabot/bundler//nokogiri-1.13.4  "
 
   check-invalid-normalize_for_image_name:
+    name: Verify Normalize Invalid Image Name
     needs: [normalize-invalid-image-name]
     runs-on: ubuntu-latest
     env:
@@ -180,7 +189,7 @@ jobs:
       registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
   copyx_image_to_latest:
-    name: Promote (Copy) Latest Multi-platform) Image
+    name: Promote (Copy) Latest Multi-platform Image
     needs:
       - pr-image-names-with-branch
       - copyx_image

--- a/.github/workflows/on_pr_checks.yml
+++ b/.github/workflows/on_pr_checks.yml
@@ -10,6 +10,25 @@ jobs:
   check-git_github_info:
     uses: ./.github/workflows/git_github_info.yml
 
+  detect-changed-files:
+    name: Detect Changed Files Using Git
+    uses: ./.github/workflows/git_detect_changed_files.yml
+    with:
+      file_pattern: git_detect_changed_files.yml
+
+  check-detect-changed-files:
+    name: Check Detect Changed Files
+    runs-on: ubuntu-latest
+    needs: detect-changed-files
+    steps:
+      - name: Check any changed
+        run: |
+          if [ "${{ needs.detect-changed-files.outputs.any_changed }}" = "true" ]; then
+            echo "Changed files detected "
+          else
+            echo "No Changed files detected"
+          fi
+
   # --- Image Name Normalizer ---
 
   normalize-valid-image-name:
@@ -132,7 +151,6 @@ jobs:
       - name: Verify Vetted Image Name
         if: ${{ success() || failure() }}
         run: test "$VETTED_IMAGE" = "${{ github.repository }}_${NORM_BRANCH}:${{ github.event.pull_request.head.sha }}"
-
 
   # --- Build/Push Multi-platform Image ---
 

--- a/.github/workflows/on_push_merge_checks.yml
+++ b/.github/workflows/on_push_merge_checks.yml
@@ -6,6 +6,25 @@ on:
 
 jobs:
 
+  detect-changed-files:
+    name: Detect Changed Files Using Git
+    uses: ./.github/workflows/git_detect_changed_files.yml
+    with:
+      file_pattern: git_detect_changed_files.yml
+
+  check-detect-changed-files:
+    name: Check Detect Changed Files
+    runs-on: ubuntu-latest
+    needs: detect-changed-files
+    steps:
+      - name: Check any changed
+        run: |
+          if [ "${{ needs.detect-changed-files.outputs.any_changed }}" = "true" ]; then
+            echo "Changed files detected "
+          else
+            echo "No Changed files detected"
+          fi
+
   # --- Image Names ---
 
   branch-and-last-commit:


### PR DESCRIPTION
# What and Why
This mostly additive changeset adds Reusable Workflow `git_detect_changed_files` to detect any changed files specified by the file_pattern regular expression.  This replaces the need for the compromised `tj-actions/changed-files` GitHub Action.

The PR and merge checks are also modified to add a call and output check of the new `git_detect_changed_files`.

## Details
The default base and target commits for new workflow are GitHub Actions *context aware* in order to serve their most common usage: to detect any file changes during a Pull Request and/or its merge.  To detect file changes `git diff --name-only` is used with the ["three dot form"](https://stackoverflow.com/a/463027) (e.g. `git diff <commit>...<commit>`) and the resulting files are compared against the `file_pattern` input using `grep -E` for regular expressions.

# Change Impact Analysis and Testing
PR and merge operations of the new workflow as well as the checks added to this repository's PR and Merge checks were vetted in this PR and merged PRs in the `gh-actions-test-bed` repository...

- [x] Successful PR and Merge Checks in another repository calling workflow with inspection of their output verifies these changes...
  - [x] brianjbayer/gh-actions-test-bed#56
  - [x] brianjbayer/gh-actions-test-bed#57
- [x] Successful PR Checks with inspection of their output verifies these changes and that their are no regressions in PR-related workflows
- [x] Successful Merge Checks with inspection of their output verifies these changes and that their are no regressions in merge-related workflows 

# Versioning
This is a purely additive and necessarily backwards-compatible change, thus...
- [x] Tagged next minor version - `v0.2.4`
- [x] "Slipped" major tag - `v0.2`


Current tags...
* Minor tag: `v0.2.3`
* Major tag: `v0.2`

```
git tag v0.2.4 && git tag -f v0.2 && git push --tags -f
```
