### PR TITLE
Add Image Registry Build Cache Support to Multiplatform Build

### DIFF
--- a/.github/workflows/buildx_amd_arm_image.yml
+++ b/.github/workflows/buildx_amd_arm_image.yml
@@ -17,23 +17,41 @@ on:
         required: true
         type: string
       buildopts:
-        description: Optional docker buildx options
+        description: Optional docker buildx options e.g. --target
         type: string
       runner_general:
-        description: "The type of runner for the general jobs in workflow (Default: ubuntu-24.04-arm)"
+        description: "The type of runner for the general jobs in workflow (ubuntu-24.04-arm)"
         required: false
         type: string
         default: ubuntu-24.04-arm
       runner_amd64:
-        description: "The type of linux/amd64 runner for this workflow (Default: ubuntu-latest)"
+        description: "The type of linux/amd64 runner for this workflow (ubuntu-latest)"
         required: false
         type: string
         default: ubuntu-latest
       runner_arm64:
-        description: "The type of linux/arm64 runner for this workflow (Default: ubuntu-24.04-arm)"
+        description: "The type of linux/arm64 runner for this workflow (ubuntu-24.04-arm)"
         required: false
         type: string
         default: ubuntu-24.04-arm
+      summary:
+        description: "Add a summary report to the workflow run (true)"
+        required: false
+        type: boolean
+        default: true
+      # Registry build caches
+      edge_build_cache_name:
+        description: 'The name of the global "edge" build cache'
+        required: false
+        type: string
+      root_build_cache_name:
+        description: 'The name of the global "root" build cache'
+        required: false
+        type: string
+      branch_build_cache_name:
+        description: 'The name of the global "branch" build cache'
+        required: false
+        type: string
 
 jobs:
 
@@ -54,21 +72,49 @@ jobs:
       - name: Image name
         run: echo "Image name [${{ inputs.image }}-${{ matrix.platform.name }}]"
 
+      - name: Login to DockerHub registry
+        run: echo ${{ secrets.registry_p }} | docker login -u ${{ secrets.registry_u }} --password-stdin
+
       - name: Set up Docker buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
-
-      - name: Login to DockerHub registry
-        run: echo ${{ secrets.registry_p }} | docker login -u ${{ secrets.registry_u }} --password-stdin
 
       - name: Buildx and push image
         env:
           DOCKER_BUILDKIT: 1
           BUILDOPTS: ${{ inputs.buildopts }}
         run: |
+          # Edge cache is both read and write
+          if [ -n "${{ inputs.edge_build_cache_name }}" ] ; then
+            edge_cache_name="${{ inputs.edge_build_cache_name }}-${{ matrix.platform.name }}"
+            echo "Using Edge Cache: [${edge_cache_name}]"
+
+            BUILDOPTS="${BUILDOPTS} --cache-from type=registry,ref=${edge_cache_name}"
+            BUILDOPTS="${BUILDOPTS} --cache-to type=registry,ref=${edge_cache_name},mode=max"
+          fi
+
+          # Root cache is read only
+          if [ -n "${{ inputs.root_build_cache_name }}" ] ; then
+            root_cache_name="${{ inputs.root_build_cache_name }}-${{ matrix.platform.name }}"
+            echo "Using Root Cache: [${root_cache_name}]"
+
+            BUILDOPTS="${BUILDOPTS} --cache-from type=registry,ref=${root_cache_name}"
+          fi
+
+          # Branch cache is both read and write
+          if [ -n "${{ inputs.branch_build_cache_name }}" ] ; then
+            branch_cache_name="${{ inputs.branch_build_cache_name }}-${{ matrix.platform.name }}"
+            echo "Using Branch Cache: [${branch_cache_name}]"
+
+            BUILDOPTS="${BUILDOPTS} --cache-from type=registry,ref=${branch_cache_name}"
+            BUILDOPTS="${BUILDOPTS} --cache-to type=registry,ref=${branch_cache_name},mode=max"
+          fi
+          echo "Build options..."
+          echo ["${BUILDOPTS}"]
+
           docker pull ${{ inputs.image }}-${{ matrix.platform.name }} \
           || docker buildx build \
-            --no-cache ${BUILDOPTS} \
+            ${BUILDOPTS} \
             --push --platform linux/${{ matrix.platform.name }} \
             --tag ${{ inputs.image }}-${{ matrix.platform.name }} \
             .
@@ -87,6 +133,10 @@ jobs:
       - name: Login to DockerHub registry
         run: echo ${{ secrets.registry_p }} | docker login -u ${{ secrets.registry_u }} --password-stdin
 
+      - name: Set up Docker buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Create and push multiplatform image
         run: |
           docker pull ${IMAGE} || docker buildx imagetools create -t ${IMAGE} ${IMAGE}-amd64 ${IMAGE}-arm64
@@ -96,3 +146,11 @@ jobs:
 
       - name: Annotate image name
         run: echo "::notice::Built and pushed multiplatform image [${IMAGE}]"
+
+      - name: Summary report
+        if: ${{ inputs.summary }}
+        run: |
+          cat <<EOF >> $GITHUB_STEP_SUMMARY
+          ### Multiplatform Image Built and Pushed
+          \`${IMAGE}\`
+          EOF

--- a/.github/workflows/buildx_push_image.yml
+++ b/.github/workflows/buildx_push_image.yml
@@ -43,15 +43,15 @@ jobs:
       - name: Image name
         run: echo "Image name [${IMAGE}]"
 
+      - name: Login to DockerHub registry
+        run: echo ${{ secrets.registry_p }} | docker login -u ${{ secrets.registry_u }} --password-stdin
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
-
-      - name: Login to DockerHub registry
-        run: echo ${{ secrets.registry_p }} | docker login -u ${{ secrets.registry_u }} --password-stdin
 
       - name: If not pull image, buildx and push image
         env:

--- a/.github/workflows/copy_image.yml
+++ b/.github/workflows/copy_image.yml
@@ -34,11 +34,11 @@ jobs:
       TARGET_IMAGE: ${{ inputs.target_image }}
 
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Login to DockerHub Registry
         run: echo ${{ secrets.registry_p }} | docker login -u ${{ secrets.registry_u }} --password-stdin
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Copy image (buildx imagetools create)
         run: |

--- a/.github/workflows/image_names.yml
+++ b/.github/workflows/image_names.yml
@@ -5,93 +5,200 @@ on:
 
     inputs:
       runner:
-        description: "The type of runner for this workflow (Default: ubuntu-latest)"
+        description: "The type of runner for this workflow (ubuntu-latest)"
         required: false
         type: string
         default: ubuntu-latest
       image_base_name:
-        description: "The name of the image including its registry and repository (Default: github.repository)"
+        description: "The name of the image including its registry and repository (github.repository)"
         required: false
         type: string
         default: ${{ github.repository }}
       add_branch_name:
-        description: Append branch name to image names
+        description: Append branch name to image names (false)
         required: false
         type: boolean
         default: false
       branch_name:
-        description: Non-normalized branch name to use if add_branch_name is true
+        description: "Non-normalized branch name to use if add_branch_name is true(github.head_ref)"
         required: false
         type: string
+        # github.head_ref is empty '' in non-PR contexts (Push/merge, workflow_dispatch)
         default: ${{ github.head_ref }}
       tag:
-        description: "Tag for image names (Default: github.event.pull_request.head.sha)"
+        description: "Tag for image names (github.event.pull_request.head.sha)"
         required: false
         type: string
         default: ${{ github.event.pull_request.head.sha }}
+      # Registry build caches
+      include_build_caches:
+        description: "Whether to include registry build cache names in the outputs"
+        required: false
+        type: boolean
+        default: true
+      build_cache_tag:
+        description: "The tag to use for the build cache images"
+        required: false
+        type: string
+        default: cache
+      edge_build_cache_root:
+        description: "The root name of the edge build cache"
+        required: false
+        type: string
+        default: "${{ github.repository_owner }}/buildcache"
+      edge_build_cache_label:
+        description: "The label to use for the edge build cache"
+        required: false
+        type: string
+        default: -ruby
+
     outputs:
-      dev_image:
-        description: The name of the development environment image
-        value: ${{ jobs.generate-pr-image-names.outputs.dev_name }}
-      dev_repository:
-        description: The name of the development environment repository
-        value: ${{ jobs.generate-pr-image-names.outputs.dev_repository }}
-      unvetted_image:
-        description: The name of the unvetted deployment image
-        value: ${{ jobs.generate-pr-image-names.outputs.unvetted_name }}
-      unvetted_repository:
-        description: The name of the unvetted deployment repository
-        value: ${{ jobs.generate-pr-image-names.outputs.unvetted_repository }}
       vetted_image:
-        description: The name of the Vetted deployment image
-        value: ${{ jobs.generate-pr-image-names.outputs.vetted_name }}
+        description: "The name of the Vetted deployment image"
+        value: ${{ jobs.generate-image-names.outputs.vetted_name }}
       vetted_repository:
-        description: The name of the Vetted deployment repository
-        value: ${{ jobs.generate-pr-image-names.outputs.vetted_repository }}
+        description: "The name of the Vetted deployment repository"
+        value: ${{ jobs.generate-image-names.outputs.vetted_repository }}
+      unvetted_image:
+        description: "The name of the unvetted deployment image"
+        value: ${{ jobs.generate-image-names.outputs.unvetted_name }}
+      unvetted_repository:
+        description: "The name of the unvetted deployment repository"
+        value: ${{ jobs.generate-image-names.outputs.unvetted_repository }}
+      dev_image:
+        description: "The name of the development environment image"
+        value: ${{ jobs.generate-image-names.outputs.dev_name }}
+      dev_repository:
+        description: "The name of the development environment repository"
+        value: ${{ jobs.generate-image-names.outputs.dev_repository }}
+      # Registry build caches
+      edge_build_cache_name:
+        description: 'The name of the global "edge" build cache'
+        value: ${{ jobs.generate-build-cache-names.outputs.edge_build_cache_name }}
+      root_build_cache_name:
+        description: 'The name of the project "root" build cache'
+        value: ${{ jobs.generate-build-cache-names.outputs.root_build_cache_name }}
+      branch_build_cache_name:
+        description: 'The name of the "branch" build cache'
+        value: ${{ jobs.generate-build-cache-names.outputs.branch_build_cache_name }}
 
 jobs:
-  pr-norm-branch:
+  norm-branch:
     name: Normalize Branch for Image Name
     uses: ./.github/workflows/normalize_for_image_name.yml
     with:
       raw_name: ${{ inputs.branch_name }}
       runner: ${{ inputs.runner }}
 
-  generate-pr-image-names:
-    name: Generate Image Names
+  generate-base-name:
+    name: Generate Base Image Name (with Branch)
     runs-on: ${{ inputs.runner }}
-    needs: [pr-norm-branch]
+    needs: norm-branch
     env:
-      BRANCH_SUFFIX: ${{ inputs.add_branch_name && format('_{0}', needs.pr-norm-branch.outputs.name) || '' }}
+      BRANCH_SUFFIX: ${{ inputs.add_branch_name && format('_{0}', needs.norm-branch.outputs.name) || '' }}
     outputs:
-      dev_name: ${{ steps.generate.outputs.dev_name }}
-      dev_repository: ${{ steps.generate.outputs.dev_repository }}
-      unvetted_name: ${{ steps.generate.outputs.unvetted_name }}
-      unvetted_repository: ${{ steps.generate.outputs.unvetted_repository }}
-      vetted_name: ${{ steps.generate.outputs.vetted_name }}
-      vetted_repository: ${{ steps.generate.outputs.vetted_repository }}
+      name: ${{ steps.generate.outputs.base_name }}
 
     steps:
-      - id: Generate
-        env:
-          DEV_REPOSITORY: ${{ inputs.image_base_name }}${{ env.BRANCH_SUFFIX }}-dev
-          UNVETTED_REPOSITORY: ${{ inputs.image_base_name }}${{ env.BRANCH_SUFFIX }}-unvetted
-          VETTED_REPOSITORY: ${{ inputs.image_base_name }}${{ env.BRANCH_SUFFIX }}
+      - id: generate
         run: |
-          echo "dev_repository=${DEV_REPOSITORY}" >> $GITHUB_OUTPUT
-          echo "dev_name=${DEV_REPOSITORY}:${{inputs.tag}}" >> $GITHUB_OUTPUT
+          base_name=${{ inputs.image_base_name }}
 
-          echo "unvetted_repository=${UNVETTED_REPOSITORY}" >> $GITHUB_OUTPUT
-          echo "unvetted_name=${UNVETTED_REPOSITORY}:${{inputs.tag}}" >> $GITHUB_OUTPUT
+          if [ "${{ inputs.add_branch_name }}" = "true" ] && \
+            [ -n "${{ needs.norm-branch.outputs.name }}" ]
+          then
+            echo "Adding non-empty branch name [${{ needs.norm-branch.outputs.name }}]"
+            base_name="${base_name}${{ format('_{0}', needs.norm-branch.outputs.name) }}"
+          fi
 
-          echo "vetted_repository=${VETTED_REPOSITORY}" >> $GITHUB_OUTPUT
-          echo "vetted_name=${VETTED_REPOSITORY}:${{inputs.tag}}" >> $GITHUB_OUTPUT
+          echo "base_name=${base_name}" >> $GITHUB_OUTPUT
+
+      - name: Show base name
+        run: |
+          echo "base-name [${{ steps.generate.outputs.base_name }}]"
+
+  generate-image-names:
+    name: Generate Image Names
+    runs-on: ${{ inputs.runner }}
+    needs:
+      - norm-branch
+      - generate-base-name
+    outputs:
+      vetted_name: ${{ steps.generate.outputs.vetted_name }}
+      vetted_repository: ${{ steps.generate.outputs.vetted_repository }}
+      unvetted_name: ${{ steps.generate.outputs.unvetted_name }}
+      unvetted_repository: ${{ steps.generate.outputs.unvetted_repository }}
+      dev_name: ${{ steps.generate.outputs.dev_name }}
+      dev_repository: ${{ steps.generate.outputs.dev_repository }}
+
+    steps:
+      - id: generate
+        run: |
+          vetted_repository=${{ needs.generate-base-name.outputs.name }}
+          echo "vetted_repository=${vetted_repository}" >> $GITHUB_OUTPUT
+          echo "vetted_name=${vetted_repository}:${{inputs.tag}}" >> $GITHUB_OUTPUT
+
+          unvetted_repository=${{ needs.generate-base-name.outputs.name }}-unvetted
+          echo "unvetted_repository=${unvetted_repository}" >> $GITHUB_OUTPUT
+          echo "unvetted_name=${unvetted_repository}:${{inputs.tag}}" >> $GITHUB_OUTPUT
+
+          dev_repository=${{ needs.generate-base-name.outputs.name }}-dev
+          echo "dev_repository=${dev_repository}" >> $GITHUB_OUTPUT
+          echo "dev_name=${dev_repository}:${{inputs.tag}}" >> $GITHUB_OUTPUT
 
       - name: Show generated names
         run: |
-          echo "dev_name            [${{ steps.generate.outputs.dev_name }}]"
-          echo "dev_repository      [${{ steps.generate.outputs.dev_repository }}]"
-          echo "unvetted_name       [${{ steps.generate.outputs.unvetted_name }}]"
-          echo "unvetted_repository [${{ steps.generate.outputs.unvetted_repository }}]"
           echo "vetted_name         [${{ steps.generate.outputs.vetted_name }}]"
           echo "vetted_repository   [${{ steps.generate.outputs.vetted_repository }}]"
+          echo ""
+          echo "unvetted_name       [${{ steps.generate.outputs.unvetted_name }}]"
+          echo "unvetted_repository [${{ steps.generate.outputs.unvetted_repository }}]"
+          echo ""
+          echo "dev_name            [${{ steps.generate.outputs.dev_name }}]"
+          echo "dev_repository      [${{ steps.generate.outputs.dev_repository }}]"
+
+  generate-build-cache-names:
+    name: Generate Build Cache Names
+    if: ${{ inputs.include_build_caches }}
+    runs-on: ${{ inputs.runner }}
+    needs:
+      - norm-branch
+      - generate-base-name
+    outputs:
+      edge_build_cache_name: ${{ steps.generate.outputs.edge_cache }}
+      root_build_cache_name: ${{ steps.generate.outputs.root_cache }}
+      branch_build_cache_name: ${{ steps.generate.outputs.branch_cache }}
+
+    steps:
+      - id: generate
+        run: |
+          edge_cache="${{ inputs.edge_build_cache_root }}${{ inputs.edge_build_cache_label }}:${{ inputs.build_cache_tag }}"
+          echo "edge_cache=${edge_cache}" >> $GITHUB_OUTPUT
+
+          root_cache="${{ inputs.image_base_name }}:${{ inputs.build_cache_tag }}"
+          echo "root_cache=${root_cache}" >> $GITHUB_OUTPUT
+
+          branch_cache='' # No branch_name case
+
+          base_image_name="${{ needs.generate-base-name.outputs.name }}"
+          if [ "${base_image_name}" != "${{ inputs.image_base_name }}" ]; then
+            echo "Branch identifier is already part of base image name"
+            branch_cache="${base_image_name}:${{ inputs.build_cache_tag }}"
+
+          else
+            echo "No branch identifier added to base name"
+            branch_name="${{ needs.norm-branch.outputs.name }}"
+            safe_branch_tag="${branch_name:0:100}"
+            if [ -n "${safe_branch_tag}" ]; then
+              echo "Adding non-empty normalized branch name to build cache tag"
+              branch_cache="${{ inputs.image_base_name }}:${{ inputs.build_cache_tag }}-${safe_branch_tag}"
+            fi
+          fi
+
+          echo "branch_cache=${branch_cache}" >> $GITHUB_OUTPUT
+
+      - name: Show generated cache names
+        run: |
+          echo "edge_cache   [${{ steps.generate.outputs.edge_cache }}]"
+          echo "root_cache   [${{ steps.generate.outputs.root_cache }}]"
+          echo "branch_cache [${{ steps.generate.outputs.branch_cache }}]"

--- a/.github/workflows/on_pr_checks.yml
+++ b/.github/workflows/on_pr_checks.yml
@@ -306,6 +306,9 @@ jobs:
     uses: ./.github/workflows/buildx_amd_arm_image.yml
     with:
       image: ${{ needs.pr-image-names-with-branch.outputs.unvetted_image }}
+      edge_build_cache_name: ${{ needs.pr-image-names-with-branch.outputs.edge_build_cache_name }}
+      root_build_cache_name: ${{ needs.pr-image-names-with-branch.outputs.root_build_cache_name }}
+      branch_build_cache_name: ${{ needs.pr-image-names-with-branch.outputs.branch_build_cache_name }}
     secrets:
       registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
       registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}

--- a/.github/workflows/on_pr_checks.yml
+++ b/.github/workflows/on_pr_checks.yml
@@ -125,33 +125,52 @@ jobs:
       UNVETTED_REPO: ${{ needs.pr-image-names-no-branch.outputs.unvetted_repository }}
       VETTED_IMAGE: ${{ needs.pr-image-names-no-branch.outputs.vetted_image }}
       VETTED_REPO: ${{ needs.pr-image-names-no-branch.outputs.vetted_repository }}
+      EDGE_CACHE_NAME: ${{ needs.pr-image-names-no-branch.outputs.edge_build_cache_name }}
+      ROOT_CACHE_NAME: ${{ needs.pr-image-names-no-branch.outputs.root_build_cache_name }}
+      BRANCH_CACHE_NAME: ${{ needs.pr-image-names-no-branch.outputs.branch_build_cache_name }}
     steps:
       - name: Image Names
         run: |
           echo "Dev Image Name      : ${DEV_IMAGE}"
           echo "Unvetted Image Name : ${UNVETTED_IMAGE}"
           echo "Vetted Image Name   : ${VETTED_IMAGE}"
-      - name: Verify Dev Image Name
-        run: test "$DEV_IMAGE" = "${{ github.repository }}-dev:${{ github.event.pull_request.head.sha }}"
-      - name: Verify Unvetted Image Name
-        if: ${{ success() || failure() }}
-        run: test "$UNVETTED_IMAGE" = "${{ github.repository }}-unvetted:${{ github.event.pull_request.head.sha }}"
       - name: Verify Vetted Image Name
         if: ${{ success() || failure() }}
         run: test "$VETTED_IMAGE" = "${{ github.repository }}:${{ github.event.pull_request.head.sha }}"
+      - name: Verify Unvetted Image Name
+        if: ${{ success() || failure() }}
+        run: test "$UNVETTED_IMAGE" = "${{ github.repository }}-unvetted:${{ github.event.pull_request.head.sha }}"
+      - name: Verify Dev Image Name
+        if: ${{ success() || failure() }}
+        run: test "$DEV_IMAGE" = "${{ github.repository }}-dev:${{ github.event.pull_request.head.sha }}"
       - name: Repository Names
         run: |
           echo "Dev Repository Name      : ${DEV_REPO}"
           echo "Unvetted Repository Name : ${UNVETTED_REPO}"
           echo "Vetted Repository Name   : ${VETTED_REPO}"
-      - name: Verify Dev Repository Name
-        run: test "$DEV_REPO" = "${{ github.repository }}-dev"
-      - name: Verify Unvetted Repository Name
-        if: ${{ success() || failure() }}
-        run: test "$UNVETTED_REPO" = "${{ github.repository }}-unvetted"
       - name: Verify Vetted Repository Name
         if: ${{ success() || failure() }}
         run: test "$VETTED_REPO" = "${{ github.repository }}"
+      - name: Verify Unvetted Repository Name
+        if: ${{ success() || failure() }}
+        run: test "$UNVETTED_REPO" = "${{ github.repository }}-unvetted"
+      - name: Verify Dev Repository Name
+        if: ${{ success() || failure() }}
+        run: test "$DEV_REPO" = "${{ github.repository }}-dev"
+      - name: Build Cache Names
+        run: |
+          echo "Edge Cache Name   : ${EDGE_CACHE_NAME}"
+          echo "Root Cache Name   : ${ROOT_CACHE_NAME}"
+          echo "Branch Cache Name : ${BRANCH_CACHE_NAME}"
+      - name: Verify Edge Cache Name
+        if: ${{ success() || failure() }}
+        run: test "$EDGE_CACHE_NAME" = "${{ github.repository_owner }}/buildcache-ruby:cache"
+      - name: Verify Root Cache Name
+        if: ${{ success() || failure() }}
+        run: test "$ROOT_CACHE_NAME" = "${{ github.repository }}:cache"
+      - name: Verify Branch Cache Name
+        if: ${{ success() || failure() }}
+        run: test "$BRANCH_CACHE_NAME" = "${{ github.repository }}:cache-${{ github.head_ref }}"
 
   pr-image-names-with-branch:
     name: Generate PR (Branch) Image Names
@@ -170,6 +189,9 @@ jobs:
       UNVETTED_REPO: ${{ needs.pr-image-names-with-branch.outputs.unvetted_repository }}
       VETTED_IMAGE: ${{ needs.pr-image-names-with-branch.outputs.vetted_image }}
       VETTED_REPO: ${{ needs.pr-image-names-with-branch.outputs.vetted_repository }}
+      EDGE_CACHE_NAME: ${{ needs.pr-image-names-with-branch.outputs.edge_build_cache_name }}
+      ROOT_CACHE_NAME: ${{ needs.pr-image-names-with-branch.outputs.root_build_cache_name }}
+      BRANCH_CACHE_NAME: ${{ needs.pr-image-names-with-branch.outputs.branch_build_cache_name }}
     steps:
       - name: Image Names
         run: |
@@ -197,6 +219,20 @@ jobs:
       - name: Verify Vetted Repository Name
         if: ${{ success() || failure() }}
         run: test "$VETTED_REPO" = "${{ github.repository }}_${{ github.head_ref }}"
+      - name: Build Cache Names
+        run: |
+          echo "Edge Cache Name   : ${EDGE_CACHE_NAME}"
+          echo "Root Cache Name   : ${ROOT_CACHE_NAME}"
+          echo "Branch Cache Name : ${BRANCH_CACHE_NAME}"
+      - name: Verify Edge Cache Name
+        if: ${{ success() || failure() }}
+        run: test "$EDGE_CACHE_NAME" = "${{ github.repository_owner }}/buildcache-ruby:cache"
+      - name: Verify Root Cache Name
+        if: ${{ success() || failure() }}
+        run: test "$ROOT_CACHE_NAME" = "${{ github.repository }}:cache"
+      - name: Verify Branch Cache Name
+        if: ${{ success() || failure() }}
+        run: test "$BRANCH_CACHE_NAME" = "${{ github.repository }}_${{ github.head_ref }}:cache"
 
   pr-image-names-override-branch:
     name: Override PR Branch Image Names
@@ -217,6 +253,9 @@ jobs:
       VETTED_IMAGE: ${{ needs.pr-image-names-override-branch.outputs.vetted_image }}
       VETTED_REPO: ${{ needs.pr-image-names-override-branch.outputs.vetted_repository }}
       NORM_BRANCH: my-branch
+      EDGE_CACHE_NAME: ${{ needs.pr-image-names-override-branch.outputs.edge_build_cache_name }}
+      ROOT_CACHE_NAME: ${{ needs.pr-image-names-override-branch.outputs.root_build_cache_name }}
+      BRANCH_CACHE_NAME: ${{ needs.pr-image-names-override-branch.outputs.branch_build_cache_name }}
     steps:
       - name: Image Names
         run: |
@@ -244,6 +283,20 @@ jobs:
       - name: Verify Vetted Repository Name
         if: ${{ success() || failure() }}
         run: test "$VETTED_REPO" = "${{ github.repository }}_${NORM_BRANCH}"
+      - name: Build Cache Names
+        run: |
+          echo "Edge Cache Name   : ${EDGE_CACHE_NAME}"
+          echo "Root Cache Name   : ${ROOT_CACHE_NAME}"
+          echo "Branch Cache Name : ${BRANCH_CACHE_NAME}"
+      - name: Verify Edge Cache Name
+        if: ${{ success() || failure() }}
+        run: test "$EDGE_CACHE_NAME" = "${{ github.repository_owner }}/buildcache-ruby:cache"
+      - name: Verify Root Cache Name
+        if: ${{ success() || failure() }}
+        run: test "$ROOT_CACHE_NAME" = "${{ github.repository }}:cache"
+      - name: Verify Branch Cache Name
+        if: ${{ success() || failure() }}
+        run: test "$BRANCH_CACHE_NAME" = "${{ github.repository }}_${NORM_BRANCH}:cache"
 
   # --- Build/Push Multi-platform Image ---
 

--- a/.github/workflows/on_pr_checks.yml
+++ b/.github/workflows/on_pr_checks.yml
@@ -298,11 +298,26 @@ jobs:
         if: ${{ success() || failure() }}
         run: test "$BRANCH_CACHE_NAME" = "${{ github.repository }}_${NORM_BRANCH}:cache"
 
+
+  # --- Refresh Registry Cache ---
+
+  refresh_branch_build_cache:
+    name: Refresh Branch Build Cache (Default)
+    needs: pr-image-names-with-branch
+    uses: ./.github/workflows/refresh_amd_arm_build_cache.yml
+    with:
+      build_cache_name: ${{ needs.pr-image-names-with-branch.outputs.branch_build_cache_name }}
+    secrets:
+      registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
+      registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
   # --- Build/Push Multi-platform Image ---
 
   buildx_push_amd_arm_image:
     name: Build Multiplatform(amd/arm) Image
-    needs: pr-image-names-with-branch
+    needs:
+      - pr-image-names-with-branch
+      - refresh_branch_build_cache
     uses: ./.github/workflows/buildx_amd_arm_image.yml
     with:
       image: ${{ needs.pr-image-names-with-branch.outputs.unvetted_image }}

--- a/.github/workflows/refresh_amd_arm_build_cache.yml
+++ b/.github/workflows/refresh_amd_arm_build_cache.yml
@@ -1,0 +1,111 @@
+name: Refresh the amd64 and arm4 Registry Build Cache
+
+on:
+  workflow_call:
+
+    secrets:
+      registry_u:
+        description: The username for the docker login
+        required: true
+      registry_p:
+        description: The password (PAT) for the docker login
+        required: true
+
+    inputs:
+      build_cache_name:
+        description: The name of the registry build cache to recreate
+        required: true
+        type: string
+      ref:
+        description: "The git reference to use as the source of the build cache (HEAD)"
+        required: false
+        type: string
+      buildopts_list:
+        description: "List of optional docker buildx options e.g --target (JSON array)"
+        type: string
+      runner_general:
+        description: "The type of runner for the general jobs in workflow (ubuntu-24.04-arm)"
+        required: false
+        type: string
+        default: ubuntu-24.04-arm
+      runner_amd64:
+        description: "The type of linux/amd64 runner for this workflow (ubuntu-latest)"
+        required: false
+        type: string
+        default: ubuntu-latest
+      runner_arm64:
+        description: "The type of linux/arm64 runner for this workflow (ubuntu-24.04-arm)"
+        required: false
+        type: string
+        default: ubuntu-24.04-arm
+      summary:
+        description: "Add a summary report to the workflow run (true)"
+        required: false
+        type: boolean
+        default: true
+
+jobs:
+
+  refresh-build-cache:
+    name: 'Refresh Registry Build Cache "${{ inputs.build_cache_name }}-${{ matrix.platform.name }}"'
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Build just the default layer as default
+        buildopts: ${{ fromJSON(inputs.buildopts_list || '[""]') }}
+        platform:
+          - name: amd64
+            runner: ${{ inputs.runner_amd64 }}
+          - name: arm64
+            runner: ${{ inputs.runner_arm64 }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build cache name
+        run: echo "Build cache name [${{ inputs.build_cache_name }}-${{ matrix.platform.name }}]"
+
+      - name: Login to DockerHub registry
+        run: echo ${{ secrets.registry_p }} | docker login -u ${{ secrets.registry_u }} --password-stdin
+
+      - name: Set up Docker buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Buildx and push cache
+        env:
+          DOCKER_BUILDKIT: 1
+          BUILDOPTS: ${{ matrix.buildopts }}
+          BUILD_CACHE: ${{ inputs.build_cache_name }}-${{ matrix.platform.name }}
+        run: |
+          echo "Build Options: [${BUILDOPTS}]"
+
+          docker buildx build \
+            ${BUILDOPTS} \
+            --platform linux/${{ matrix.platform.name }} \
+            --cache-from=type=registry,ref=${BUILD_CACHE},max=0 \
+            --cache-to=type=registry,ref=${BUILD_CACHE},mode=max \
+            -t notpushedanyway:latest .
+
+      - name: Logout of DockerHub registry
+        run: docker logout
+
+  report:
+    name: Report on Registry Build Cache Refresh
+    runs-on: ${{ inputs.runner_general }}
+    needs: refresh-build-cache
+    env:
+      BUILD_CACHE_NAME: ${{ inputs.build_cache_name }}
+
+    steps:
+
+      - name: Annotate build cache refresh
+        run: echo "::notice::Recreated registry build cache [${BUILD_CACHE_NAME}]"
+
+      - name: Summary report
+        if: ${{ inputs.summary }}
+        run: |
+          cat <<EOF >> $GITHUB_STEP_SUMMARY
+          ### Multiplatform Registry Build Cache Rebuild
+          Refreshed Build Cache: \`${BUILD_CACHE_NAME}\`
+          EOF

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # actions-image-cicd
+
 This repository contains Reusable GitHub Actions Workflows
 that can be called by other GitHub Actions Workflows to
 reduce duplication, effort, and risk.
@@ -16,86 +17,162 @@ and the gist [The Basics of GitHub Actions Reusable Workflows](https://gist.gith
 
 ### Reusable Workflows
 
+#### buildx_amd_arm_image.yml
+
+Idempotent multi-platform amd64/arm64 image build and push workflow.
+
+**Inputs:**
+
+- `image` - Name of the image to build and push (required)
+- `buildopts` - Optional docker buildx options (e.g. --target)
+- `runner_general` - Runner for general jobs (default: ubuntu-24.04-arm)
+- `runner_amd64` - Runner for linux/amd64 builds (default: ubuntu-latest)
+- `runner_arm64` - Runner for linux/arm64 builds (default: ubuntu-24.04-arm)
+- `summary` - Add summary report (default: true)
+- `edge_build_cache_name` - Edge build cache name (optional)
+- `root_build_cache_name` - Root build cache name (optional)
+- `branch_build_cache_name` - Branch build cache name (optional)
+
+**Secrets:**
+
+- `registry_u` - Docker registry username
+- `registry_p` - Docker registry password/PAT
+
 #### buildx_push_image.yml
+
 Idempotent multi-platform image build and push workflow.
 
 **Inputs:**
+
 - `image` - Name of the image to build and push (required)
 - `platforms` - Image platforms to build (required)
 - `buildopts` - Optional docker buildx options
 - `runner` - Type of runner (default: ubuntu-latest)
 
 **Secrets:**
+
 - `registry_u` - Docker registry username
 - `registry_p` - Docker registry password/PAT
 
 #### copy_image.yml
+
 Copies/promotes an image from one tag to another.
 
 **Inputs:**
+
 - `from_image` - Source image to copy from (required)
 - `to_image` - Target image to copy to (required)
 - `runner` - Runner type (default: ubuntu-latest)
 
 **Secrets:**
+
 - `registry_u` - Docker registry username
 - `registry_p` - Docker registry password/PAT
 
+#### image_names.yml
+
+Development, unvetted, and vetted deployment image name generation.
+
+**Inputs:**
+
+- `runner` - Runner type (default: ubuntu-latest)
+- `image_base_name` - Image name including registry and repository (default: github.repository)
+- `add_branch_name` - Append branch name to image names (default: false)
+- `branch_name` - Non-normalized branch name (default: github.head_ref)
+- `tag` - Tag for image names (default: github.event.pull_request.head.sha)
+- `include_build_caches` - Include registry build cache names (default: true)
+- `build_cache_tag` - Tag for build cache images (default: cache)
+- `edge_build_cache_root` - Edge build cache root name (default: github.repository_owner/buildcache)
+- `edge_build_cache_label` - Edge build cache label (default: -ruby)
+
+**Outputs:**
+
+- `vetted_image` - Vetted deployment image name
+- `vetted_repository` - Vetted deployment repository name
+- `unvetted_image` - Unvetted deployment image name
+- `unvetted_repository` - Unvetted deployment repository name
+- `dev_image` - Development environment image name
+- `dev_repository` - Development environment repository name
+- `edge_build_cache_name` - Global edge build cache name
+- `root_build_cache_name` - Project root build cache name
+- `branch_build_cache_name` - Branch build cache name
+
 #### delete_docker_hub_repositories.yml
+
 Matrix-based deletion of Docker Hub repositories.
 
 **Inputs:**
+
 - `repositories` - JSON array of repository names to delete (required)
 - `runner` - Runner type (default: ubuntu-latest)
 - `summary` - Add summary report (default: true)
 - `ref` - Git reference for action checkout (optional)
 
 **Secrets:**
+
 - `registry_u` - Docker registry username
 - `registry_p` - Docker registry password/PAT
 
 #### get_merged_branch_last_commit.yml
+
 Gets merged branch and last commit information.
 
 **Outputs:**
+
 - `merged_branch` - The name of the merged branch
 - `last_commit` - The SHA of the last commit
 
-#### image_names.yml
-Image name normalization and validation.
+#### refresh_amd_arm_build_cache.yml
+
+Refresh amd64 and arm64 registry build cache.
 
 **Inputs:**
-- `name_base` - Base name for the image (required)
-- `branch` - Branch name for tag (required)
 
-**Outputs:**
-- `normalized_name` - Docker-compatible normalized image name
+- `build_cache_name` - Registry build cache name to recreate (required)
+- `ref` - Git reference for build cache source (default: HEAD)
+- `buildopts_list` - JSON array of docker buildx options (e.g. ["", "--target"])
+- `runner_general` - Runner for general jobs (default: ubuntu-24.04-arm)
+- `runner_amd64` - Runner for linux/amd64 builds (default: ubuntu-latest)
+- `runner_arm64` - Runner for linux/arm64 builds (default: ubuntu-24.04-arm)
+- `summary` - Add summary report (default: true)
+
+**Secrets:**
+
+- `registry_u` - Docker registry username
+- `registry_p` - Docker registry password/PAT
 
 #### latest_tag.yml
+
 Latest tag for reuse in calling Reusable Workflows (`with:`)
 
 **Inputs:**
+
 - `latest_tag` - Tag for latest image names (Default: latest)
 
 **Outputs:**
+
 - `tag` - The latest tag
 
 ### Actions (Dockerfile-based)
 
 #### delete-docker-hub-repository
+
 Container action to delete a Docker Hub repository.
 
 **Inputs:**
+
 - `docker-hub-repository` - Repository name to delete (required)
 - `docker-hub-username` - Docker Hub username (required)
 - `docker-hub-password` - Docker Hub password/token (required)
 
 ## Intent of the Workflows
+
 These workflows were designed to be simple cohesive building blocks called
 within the using repository's own customized workflows where the high-level
 logic is.
 
 ## Using These Reusable Workflows
+
 > :warning: the `.github/workflows/on_*_checks.yml` workflows are
 > **not** reusable.
 
@@ -105,12 +182,13 @@ The GitHub Actions
 
 Examples of using and calling the reusable workflows in this repository
 can be found in the _Checks_ for this repository.  See...
-  * [.github/workflows/on_pr_checks.yml](https://github.com/brianjbayer/actions-image-cicd/blob/main/.github/workflows/on_pr_checks.yml)
 
-  * [.github/workflows/on_push_merge_checks.yml](https://github.com/brianjbayer/actions-image-cicd/blob/main/.github/workflows/on_push_merge_checks.yml)
+* [.github/workflows/on_pr_checks.yml](https://github.com/brianjbayer/actions-image-cicd/blob/main/.github/workflows/on_pr_checks.yml)
 
+* [.github/workflows/on_push_merge_checks.yml](https://github.com/brianjbayer/actions-image-cicd/blob/main/.github/workflows/on_push_merge_checks.yml)
 
 ## Intended CI/CD Flow
+
 These workflows were developed specifically for a CI/CD flow where a commit
 image is considered the release candidate image.  If the image passes all
 automated CI checks and tests, then it is promoted as a release candidate.
@@ -136,17 +214,21 @@ it is not so available in the Push (i.e. merge) Actions.
 
 With this intended CI/CD, there are two basic GitHub Actions workflows...
   * **On Pull Request...**
+
     1. Build and push unvetted potential release candidate image from
        commit using:
+
        ```
        .github/workflows/buildx_push_image.yml@v0.2.0
        ```
+
     2. Pull and perform vetting (e.g. linting, security scans,
        unit tests, end-to-end tests etc) on pushed unvetted potential
        release candidate image
     3. If all vetting checks passed, promote the unvetted potential
        release candidate image to an actual release candidate image
        using:
+
        ```
        .github/workflows/copy_image.yml@v0.2.0
        ```
@@ -154,15 +236,20 @@ With this intended CI/CD, there are two basic GitHub Actions workflows...
   * **On Push to main (merge)...**
     1. Get the merged branch and the last commit of it to determine
       the release candidate image name using:
+
        ```
        .github/workflows/get_merged_branch_last_commit.yml@v0.2.0
        ```
+
     2. Promote the release candidate image to production using:
+
        ```
        .github/workflows/copy_image.yml@v0.2.0
        ```
+
     3. Optionally tag the just promoted production image as latest
        using:
+
        ```
        .github/workflows/copy_image_to_latest.yml@v0.2.0
        ```
@@ -171,6 +258,7 @@ For more on image-based CI/CD, see the gist
 [An Image-Based Continuous Integration / Continuous Deployment Model](https://gist.github.com/brianjbayer/e5e9f07e0923d8d097d7b03803ea837b).
 
 ## Testing
+
 When modifying/developing workflows in this repository, changes should
 be on a branch in this repository and tested (especially merge/on push
 related workflows) using another test bed repository to call these


### PR DESCRIPTION
# What
:green_circle: These changes are backwards compatible adding new workflow and new optional inputs/outputs requiring a new patch release `v0.2.7`

This changeset...
1. Adds optional support for Multilevel Docker Registry Build Caches to the multiplatform image building Reusable Workflow `buildx_amd_arm_image`
  1. A global *Edge* cache (shared across projects with same base image)
  2. A project-specific *Root* cache (based on `latest`)
  3. A *Branch* cache for the PR
4. Adds a **new** Reusable Workflow `refresh_amd_arm_build_cache` to rebuild a registry build cache for all layers (`buildopts_list`) for both `amd` and `arm` architectures
5. Adds build cache name outputs for the multilayer caches to Reusable Workflow `image_names`
6. Reorders the Docker login **before** using any `actions` that pull images to avoid anonymous pull limits in appropriate Reusable Workflows
7. Adds (default) a Step Summary in `buildx_amd_arm_image` that outputs the name of the built and pushed multiplatform image
![Add_Image_Build_Caches_·_brianjbayer_actions-image-cicd_e78ad51](https://github.com/user-attachments/assets/bd874c33-7ef5-4847-93a6-88455774e963)

# Why
Properly used build caching can significantly reduce image build time and CI usage.  More reliable builds with better reporting.

:warning: Since each cache is actually architecture-specific, using all three caches results in six actual additional pulls which may cause pull limiting depending on the type of account.  

# Change Impact Analysis and Testing
PR Checks were updated to exercise and verify the modified Reusable Workflows.  To fully verify these modified and new Reusable Workflows, they were used on this branch in the  GH Actions test bed project PR.

- [x] Successful PR Checks and their inspection verifies these changes in relation to this project and that there are no regressions
- [x] README changes manually inspected rendered on this branch
- [x] Successful PR and Merge Checks in related testing PR brianjbayer/gh-actions-test-bed#61

# Versioning
:green_circle: These changes are backwards compatible adding new workflow and new optional inputs/outputs requiring a new patch release `v0.2.7` and slip of current minor tag `v0.2`.

```bash
git tag v0.2.7 && git tag -f `v0.2` && git push --tags -f
```

