### PR TITLE
Authorize Before All (Hub) Image Pulls, Make Platform Builds Optional, TODO

### DIFF
--- a/.github/actions/merge-commit-pr-info/Dockerfile
+++ b/.github/actions/merge-commit-pr-info/Dockerfile
@@ -1,0 +1,36 @@
+#--- Base Image ---
+# Ruby version must match that in Gemfile.lock
+ARG BASE_IMAGE=ruby:4.0.4-slim-trixie
+FROM ${BASE_IMAGE} AS ruby-base
+
+#--- Installer Stage ---
+FROM ruby-base AS installer
+
+# Gem versions
+ARG OCTOKIT_VERSION=10.0.0
+ARG FARADAY_RETRY_VERSION=2.4.0
+
+# Update gem command to latest
+RUN gem update --system \
+# Install gems
+  && gem install \
+  "octokit:${OCTOKIT_VERSION}" \
+  "faraday-retry:${FARADAY_RETRY_VERSION}"
+
+WORKDIR /app
+
+#--- Development Environment Stage ---
+# Assume volume mounting
+FROM installer AS devenv
+
+# Start devenv in (command line) shell
+CMD ["bash"]
+
+#--- Run Action Stage ---
+FROM installer AS run-action
+
+# Make the entrypoint script executable
+COPY --chmod=0755 merge-commit-pr-info.rb /merge-commit-pr-info.rb
+
+# Set the entrypoint to the script
+ENTRYPOINT ["/merge-commit-pr-info.rb"]

--- a/.github/actions/merge-commit-pr-info/README.md
+++ b/.github/actions/merge-commit-pr-info/README.md
@@ -1,0 +1,303 @@
+# merge-commit-pr-info
+
+GitHub Action that resolves Pull Request information from a merge commit SHA.
+
+This action is useful in workflows triggered after merges where only the merge commit SHA is available and you need metadata about the merged PR such as:
+
+- PR number
+- PR title
+- PR URL
+- Source (PR) branch
+- Target (base) branch
+- Last commit on source branch
+- Last commit on target branch before merge
+
+The action uses the GitHub API endpoint that associates pull requests with a commit SHA.
+
+---
+
+## Features
+
+- Docker-based GitHub Action
+- Uses the GitHub API via Ruby + Octokit
+- Works with merge commits
+- Exposes PR metadata as workflow outputs
+- Minimal runtime dependencies
+
+---
+
+## Inputs
+
+| Name | Required | Description |
+|---|---|---|
+| `github-owner-repo` | yes | Repository in `owner/repo` format |
+| `merge-commit-sha` | yes | Merge commit SHA |
+| `github-token` | yes | GitHub token with repository read access |
+
+---
+
+## Outputs
+
+| Output | Description |
+|---|---|
+| `number` | PR number |
+| `title` | PR title |
+| `url` | PR URL |
+| `branch` | PR source branch (`head.ref`) |
+| `last-commit` | Last commit SHA on PR branch |
+| `base-branch` | Target branch of merge (`base.ref`) |
+| `base-last-commit` | Last commit SHA on base branch before merge |
+
+---
+
+## Usage
+
+### Basic Example
+
+```yaml
+name: Resolve PR Info
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  pr-info:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get PR info from merge commit
+        id: pr-info
+        uses: your-org/merge-commit-pr-info@v1
+        with:
+          github-owner-repo: ${{ github.repository }}
+          merge-commit-sha: ${{ github.sha }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Print outputs
+        run: |
+          echo "PR Number: ${{ steps.pr-info.outputs.number }}"
+          echo "PR Title: ${{ steps.pr-info.outputs.title }}"
+          echo "PR URL: ${{ steps.pr-info.outputs.url }}"
+          echo "PR Branch: ${{ steps.pr-info.outputs.branch }}"
+          echo "PR Last Commit: ${{ steps.pr-info.outputs.last-commit }}"
+          echo "Base Branch: ${{ steps.pr-info.outputs.base-branch }}"
+          echo "Base Last Commit: ${{ steps.pr-info.outputs.base-last-commit }}"
+```
+
+---
+
+## Example Outputs
+
+```text
+number=42
+title=Add authentication middleware
+url=https://github.com/acme/api/pull/42
+branch=feature/auth-middleware
+last-commit=abc123def456
+base-branch=main
+base-last-commit=987zyx654wvu
+```
+
+---
+
+## Local Development
+
+### Prerequisites
+
+- Docker (Desktop) installed and running
+
+---
+
+## Local Test Plan
+
+### 1. Clone Repository
+
+```bash
+git clone git@github.com:YOUR_ORG/merge-commit-pr-info.git
+cd merge-commit-pr-info
+```
+
+---
+
+### 2. Build Docker Image
+
+```bash
+docker build -t merge-commit-pr-info .
+```
+
+Expected result:
+
+```text
+Successfully tagged merge-commit-pr-info:latest
+```
+
+---
+
+### 3. Create GitHub Personal Access Token
+
+Create a token with:
+
+- `repo` scope for private repositories
+- public repo access for public repositories
+
+Export token:
+
+```bash
+export GITHUB_TOKEN=ghp_your_token_here
+```
+
+---
+
+### 4. Identify a Merge Commit SHA
+
+Example:
+
+```bash
+git log --merges --oneline
+```
+
+Copy a merge commit SHA.
+
+Example:
+
+```text
+a1b2c3d Merge pull request #42 from feature/example
+```
+
+---
+
+### 5. Create Local Output File
+
+GitHub Actions normally injects `GITHUB_OUTPUT`.
+
+Simulate locally:
+
+```bash
+touch github-output.txt
+```
+
+---
+
+### 6. Run Action Container Locally
+
+```bash
+docker run --rm \
+  -e GITHUB_TOKEN="$GITHUB_TOKEN" \
+  -e GITHUB_OWNER_REPOSITORY="owner/repository" \
+  -e MERGE_COMMIT="a1b2c3d4e5f6..." \
+  -e GITHUB_OUTPUT="/tmp/github-output.txt" \
+  -v "$(pwd)/github-output.txt:/tmp/github-output.txt" \
+  merge-commit-pr-info
+```
+
+---
+
+### 7. Inspect Outputs
+
+```bash
+cat github-output.txt
+```
+
+Example:
+
+```text
+number=42
+title=Add authentication middleware
+url=https://github.com/acme/api/pull/42
+branch=feature/auth-middleware
+last-commit=abc123def456
+base-branch=main
+base-last-commit=987zyx654wvu
+```
+
+---
+
+## Development Environment Container
+
+The Dockerfile includes a development stage named `devenv`.
+
+Start interactive shell:
+
+```bash
+docker build --target devenv -t merge-commit-pr-info-dev .
+```
+
+Run shell:
+
+```bash
+docker run --rm -it \
+  -v "$(pwd):/app" \
+  merge-commit-pr-info-dev
+```
+
+Inside container:
+
+```bash
+ruby merge-commit-pr-info.rb
+```
+
+---
+
+## Testing Against a Real Repository
+
+Example:
+
+```bash
+docker run --rm \
+  -e GITHUB_TOKEN="$GITHUB_TOKEN" \
+  -e GITHUB_OWNER_REPOSITORY="octocat/Hello-World" \
+  -e MERGE_COMMIT="MERGE_SHA_HERE" \
+  -e GITHUB_OUTPUT="/tmp/github-output.txt" \
+  -v "$(pwd)/github-output.txt:/tmp/github-output.txt" \
+  merge-commit-pr-info
+```
+
+---
+
+## Error Conditions
+
+The action intentionally fails when:
+
+### No Matching PR Found
+
+```text
+No PR found where this SHA is the merge commit!
+```
+
+Possible causes:
+
+- SHA is not a merge commit
+- commit does not belong to a PR
+- wrong repository specified
+
+---
+
+### Multiple Matching PRs
+
+```text
+More than one PR with merge commit: Found PR #s [...]
+```
+
+This should be extremely rare and indicates ambiguous repository state.
+
+---
+
+## Debugging
+
+Enable verbose Docker output:
+
+```bash
+docker run --rm -it \
+  --entrypoint bash \
+  merge-commit-pr-info
+```
+
+Test Ruby script manually:
+
+```bash
+ruby /merge-commit-pr-info.rb
+```
+
+---

--- a/.github/actions/merge-commit-pr-info/action.yml
+++ b/.github/actions/merge-commit-pr-info/action.yml
@@ -1,0 +1,39 @@
+name: Merge Commit PR Info
+description: "Returns information about the PR for the merge commit"
+
+inputs:
+  github-owner-repo:
+    description: "The owner/repository of the PR"
+    required: true
+  merge-commit-sha:
+    description: "The commit merging the PR"
+    required: true
+
+  # Secrets
+  github-token:
+    description: "Github Repository Access Token (e.g. secrets.GITHUB_TOKEN)"
+    required: true
+
+outputs:
+  number:
+    description: "PR number"
+  title:
+    description: "PR Title"
+  url:
+    description: "PR URL"
+  branch:
+    description: "PR Branch (head.ref)"
+  last-commit:
+    description: "Last commit on PR Branch"
+  base-branch:
+    description: "Target branch of PR merge (base.ref)"
+  base-last-commit:
+    description: "Last commit on base branch before merge"
+
+runs:
+  using: docker
+  image: Dockerfile
+  env:
+    GITHUB_OWNER_REPOSITORY: ${{ inputs.github-owner-repo }}
+    MERGE_COMMIT: ${{ inputs.merge-commit-sha }}
+    GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/.github/actions/merge-commit-pr-info/merge-commit-pr-info.rb
+++ b/.github/actions/merge-commit-pr-info/merge-commit-pr-info.rb
@@ -1,0 +1,50 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'octokit'
+
+# Required inputs
+github_access_token = ENV.fetch('GITHUB_TOKEN')
+owner_repository = ENV.fetch('GITHUB_OWNER_REPOSITORY')
+merge_commit = ENV.fetch('MERGE_COMMIT')
+
+# Authorize
+client = Octokit::Client.new(access_token: github_access_token)
+
+# List pull requests associated with the commit SHA
+puts "Searching Repository #{owner_repository} for merge commit #{merge_commit}"
+# This endpoint identifies the PR that was merged by this specific SHA
+prs = client.commit_pulls(owner_repository, merge_commit)
+
+# Expect there to be at least one
+matching_prs = prs.select { |pr| pr.merge_commit_sha == merge_commit }
+raise "No PR found where this SHA is the merge commit!" if matching_prs.empty?
+
+# And only one
+if matching_prs.size > 1
+  pr_numbers = matching_prs.map(&:number).join(', ')
+  raise "More than one PR with merge commit: Found PR #s [#{pr_numbers}]!"
+end
+target_pr = matching_prs.first
+
+# PR Attributes
+pr_info = {
+  number: target_pr.number,
+  title: target_pr.title,
+  url: target_pr.html_url,
+  branch: target_pr.head.ref,
+  last_commit_on_branch: target_pr.head.sha,
+  base_branch: target_pr.base.ref,
+  last_commit_on_base: target_pr.base.sha
+}
+
+# Write to Github Actions output
+File.open(ENV.fetch('GITHUB_OUTPUT'), 'a') do |f|
+  pr_info.each do |key, value|
+    # Transform ruby_underscore to action-dash ("last_commit" to "last-commit")
+    github_key = key.to_s.tr('_', '-')
+    set_github_action_output = "#{github_key}=#{value}"
+    puts set_github_action_output
+    f.puts(set_github_action_output)
+  end
+end

--- a/.github/workflows/buildx_amd_arm_image.yml
+++ b/.github/workflows/buildx_amd_arm_image.yml
@@ -30,10 +30,15 @@ on:
         type: string
         default: ubuntu-latest
       amd64_tag:
-        description: "The amd64 architecture tag/name"
+        description: "The amd64 architecture tag/name (amd64)"
         required: false
         type: string
         default: amd64
+      amd64_platform:
+        description: "The amd64 platform(linux/amd64)"
+        required: false
+        type: string
+        default: linux/amd64
       runner_arm64:
         description: "The type of linux/arm64 runner for this workflow (ubuntu-24.04-arm)"
         required: false
@@ -44,6 +49,11 @@ on:
         required: false
         type: string
         default: arm64
+      arm64_platform:
+        description: "The arm64 platform(linux/arm64)"
+        required: false
+        type: string
+        default: linux/arm64
       summary:
         description: "Add a summary report to the workflow run (true)"
         required: false
@@ -65,8 +75,35 @@ on:
 
 jobs:
 
+  platform-image-names:
+   name: Set the platform image name if building
+   runs-on: ${{ inputs.runner_general }}
+   env:
+    AMD_IMAGE: ${{ inputs.image }}-${{ inputs.amd64_tag }}
+    ARM_IMAGE: ${{ inputs.image }}-${{ inputs.arm64_tag }}
+   outputs:
+    amd-name: ${{ steps.if-build.outputs.amd-name }}
+    arm-name: ${{ steps.if-build.outputs.arm-name }}
+   steps:
+    - id: if-build
+      run: |
+        [ -n "${{ inputs.runner_amd64 }}" ] && echo "amd-name=${AMD_IMAGE}" >> $GITHUB_OUTPUT || true
+        [ -n "${{ inputs.runner_arm64 }}" ] && echo "arm-name=${ARM_IMAGE}" >> $GITHUB_OUTPUT || true
+
+    - name: Verify a platform
+      run: |
+        if [ -z "${{ steps.if-build.outputs.amd-name }}" ] && [ -z "${{ steps.if-build.outputs.arm-name }}" ]; then
+          error_message='At least one platform must be built - no platform runners specified'
+          echo "${error_message}"
+          echo "::error::${error_message}"
+          exit 1
+        fi
+        echo "AMD Platform Image: [${{ steps.if-build.outputs.amd-name }}]"
+        echo "ARM Platform Image: [${{ steps.if-build.outputs.arm-name }}]"
+
   buildx-and-push-image:
     name: Build and Push Platform Image
+    needs: platform-image-names
     runs-on: ${{ matrix.platform.runner || inputs.runner_general }}
     strategy:
       fail-fast: false
@@ -74,41 +111,34 @@ jobs:
         platform:
           - name: ${{ inputs.amd64_tag }}
             runner: ${{ inputs.runner_amd64 }}
+            image: ${{ needs.platform-image-names.outputs.amd-name }}
+            value: ${{ inputs.amd64_platform }}
           - name: ${{ inputs.arm64_tag }}
             runner: ${{ inputs.runner_arm64 }}
+            image: ${{ needs.platform-image-names.outputs.arm-name }}
+            value: ${{ inputs.arm64_platform }}
+
     steps:
-
-      - name: Platform image name if build platform
-        id: if-build-platform
-        run: |
-          if [ -z "${{ matrix.platform.runner }}" ]]; then
-            echo "Skipping build of ${{ matrix.platform.name }} image"
-          else
-            platform_image_name="${{ inputs.image }}-${{ matrix.platform.name }}"
-            echo "Building ${{ matrix.platform.name }} image [${platform_image_name}]"
-
-            echo "platform_image=${platform_image_name}" >> $GITHUB_OUTPUT
-          fi
 
       - name: Checkout repository
         uses: actions/checkout@v4
-        if: 'steps.if-build-platform.outputs.platform_image'
+        if:  matrix.platform.image
 
       - name: Image name
-        if: 'steps.if-build-platform.outputs.platform_image'
-        run: echo "Image name [${{ steps.if-build-platform.outputs.platform_image }}]"
+        if:  matrix.platform.image
+        run: echo "Image name [${{ matrix.platform.image }}]"
 
       - name: Login to DockerHub registry
-        if: 'steps.if-build-platform.outputs.platform_image'
+        if:  matrix.platform.image
         run: echo ${{ secrets.registry_p }} | docker login -u ${{ secrets.registry_u }} --password-stdin
 
       - name: Set up Docker buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
-        if: 'steps.if-build-platform.outputs.platform_image'
+        if:  matrix.platform.image
 
       - name: Buildx and push image
-        if: 'steps.if-build-platform.outputs.platform_image'
+        if:  matrix.platform.image
         env:
           DOCKER_BUILDKIT: 1
           BUILDOPTS: ${{ inputs.buildopts }}
@@ -141,40 +171,36 @@ jobs:
           echo "Build options..."
           echo ["${BUILDOPTS}"]
 
-          docker pull ${{ inputs.image }}-${{ matrix.platform.name }} \
+          docker pull ${{ matrix.platform.image }} \
           || docker buildx build \
             ${BUILDOPTS} \
-            --push --platform linux/${{ matrix.platform.name }} \
-            --tag ${{ inputs.image }}-${{ matrix.platform.name }} \
+            --push --platform ${{ matrix.platform.value }} \
+            --tag ${{ matrix.platform.image }} \
             .
 
       - name: Logout of DockerHub registry
-        if: 'steps.if-build-platform.outputs.platform_image'
+        if:  matrix.platform.image
         run: docker logout
 
-
       - name: Platform build summary
-        if: 'steps.if-build-platform.outputs.platform_image'
+        if:  matrix.platform.image
         run: |
-          image_fragment="<code>${{ steps.if-build-platform.outputs.platform_image }}</code>"
+          image_fragment="<code>${{ matrix.platform.image }}</code>"
           summary="<b>Built and Pushed <code>${{ matrix.platform.name }}</code> Image:</b><br>${image_fragment}"
           echo "${summary}" >> $GITHUB_STEP_SUMMARY
 
   combine-images:
     name: Create Multiplatform Image
     runs-on: ${{ inputs.runner_general }}
-    needs: buildx-and-push-image
+    needs:
+      - platform-image-names
+      - buildx-and-push-image
     env:
       IMAGE: ${{ inputs.image }}
+      AMD_IMAGE: ${{ needs.platform-image-names.outputs.amd-name }}
+      ARM_IMAGE: ${{ needs.platform-image-names.outputs.arm-name }}
 
     steps:
-
-      - name: There must be a platform
-        run: |
-         if [ -z "${{ inputs.runner_amd64 }}" ] && [ -z "${{ inputs.runner_arm64 }}" ]; then
-           echo "::error::At least must platform must be built - no platform runner specified"
-           exit 1
-         fi
 
       - name: Login to DockerHub registry
         run: echo ${{ secrets.registry_p }} | docker login -u ${{ secrets.registry_u }} --password-stdin
@@ -185,10 +211,9 @@ jobs:
 
       - name: Create and push multiplatform image
         run: |
-          IMAGES=''
-          [ -n "${{ inputs.runner_amd64 }}" ] && IMAGES="${IMAGES} ${{ inputs.image }}-${{ inputs.amd64_tag }}"
-          [ -n "${{ inputs.runner_arm64 }}" ] && IMAGES="${IMAGES} ${{ inputs.image }}-${{ inputs.arm64_tag }}"
-          docker pull ${IMAGE} || docker buildx imagetools create -t ${IMAGE} ${IMAGES}
+          # AT least one platform image is expected/must exist
+          PLATFORM_IMAGES="${AMD_IMAGE} ${ARM_IMAGE}"
+          docker pull ${IMAGE} || docker buildx imagetools create -t ${IMAGE} ${PLATFORM_IMAGES}
 
       - name: Logout of DockerHub registry
         run: docker logout

--- a/.github/workflows/buildx_amd_arm_image.yml
+++ b/.github/workflows/buildx_amd_arm_image.yml
@@ -93,11 +93,22 @@ jobs:
     - name: Verify a platform
       run: |
         if [ -z "${{ steps.if-build.outputs.amd-name }}" ] && [ -z "${{ steps.if-build.outputs.arm-name }}" ]; then
+          # Error: No platforms to build
+
           error_message='At least one platform must be built - no platform runners specified'
           echo "${error_message}"
+
+          # Annotate error
           echo "::error::${error_message}"
+
+          # Summary of error
+          summary="<b>:x: ${error_message}</b>"
+          echo "${summary}" >> $GITHUB_STEP_SUMMARY
+
+          # EXIT
           exit 1
         fi
+
         echo "AMD Platform Image: [${{ steps.if-build.outputs.amd-name }}]"
         echo "ARM Platform Image: [${{ steps.if-build.outputs.arm-name }}]"
 

--- a/.github/workflows/buildx_amd_arm_image.yml
+++ b/.github/workflows/buildx_amd_arm_image.yml
@@ -29,11 +29,21 @@ on:
         required: false
         type: string
         default: ubuntu-latest
+      amd64_tag:
+        description: "The amd64 architecture tag/name"
+        required: false
+        type: string
+        default: amd64
       runner_arm64:
         description: "The type of linux/arm64 runner for this workflow (ubuntu-24.04-arm)"
         required: false
         type: string
         default: ubuntu-24.04-arm
+      arm64_tag:
+        description: "The arm64 architecture tag/name"
+        required: false
+        type: string
+        default: arm64
       summary:
         description: "Add a summary report to the workflow run (true)"
         required: false
@@ -57,31 +67,48 @@ jobs:
 
   buildx-and-push-image:
     name: Build and Push Platform Image
-    runs-on: ${{ matrix.platform.runner }}
+    runs-on: ${{ matrix.platform.runner || inputs.runner_general }}
     strategy:
       fail-fast: false
       matrix:
         platform:
-          - name: amd64
+          - name: ${{ inputs.amd64_tag }}
             runner: ${{ inputs.runner_amd64 }}
-          - name: arm64
+          - name: ${{ inputs.arm64_tag }}
             runner: ${{ inputs.runner_arm64 }}
     steps:
 
+      - name: Platform image name if build platform
+        id: if-build-platform
+        run: |
+          if [ -z "${{ matrix.platform.runner }}" ]]; then
+            echo "Skipping build of ${{ matrix.platform.name }} image"
+          else
+            platform_image_name="${{ inputs.image }}-${{ matrix.platform.name }}"
+            echo "Building ${{ matrix.platform.name }} image [${platform_image_name}]"
+
+            echo "platform_image=${platform_image_name}" >> $GITHUB_OUTPUT
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@v4
+        if: 'steps.if-build-platform.outputs.platform_image'
 
       - name: Image name
-        run: echo "Image name [${{ inputs.image }}-${{ matrix.platform.name }}]"
+        if: 'steps.if-build-platform.outputs.platform_image'
+        run: echo "Image name [${{ steps.if-build-platform.outputs.platform_image }}]"
 
       - name: Login to DockerHub registry
+        if: 'steps.if-build-platform.outputs.platform_image'
         run: echo ${{ secrets.registry_p }} | docker login -u ${{ secrets.registry_u }} --password-stdin
 
       - name: Set up Docker buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
+        if: 'steps.if-build-platform.outputs.platform_image'
 
       - name: Buildx and push image
+        if: 'steps.if-build-platform.outputs.platform_image'
         env:
           DOCKER_BUILDKIT: 1
           BUILDOPTS: ${{ inputs.buildopts }}
@@ -122,7 +149,16 @@ jobs:
             .
 
       - name: Logout of DockerHub registry
+        if: 'steps.if-build-platform.outputs.platform_image'
         run: docker logout
+
+
+      - name: Platform build summary
+        if: 'steps.if-build-platform.outputs.platform_image'
+        run: |
+          image_fragment="<code>${{ steps.if-build-platform.outputs.platform_image }}</code>"
+          summary="<b>Built and Pushed <code>${{ matrix.platform.name }}</code> Image:</b><br>${image_fragment}"
+          echo "${summary}" >> $GITHUB_STEP_SUMMARY
 
   combine-images:
     name: Create Multiplatform Image
@@ -132,6 +168,14 @@ jobs:
       IMAGE: ${{ inputs.image }}
 
     steps:
+
+      - name: There must be a platform
+        run: |
+         if [ -z "${{ inputs.runner_amd64 }}" ] && [ -z "${{ inputs.runner_arm64 }}" ]; then
+           echo "::error::At least must platform must be built - no platform runner specified"
+           exit 1
+         fi
+
       - name: Login to DockerHub registry
         run: echo ${{ secrets.registry_p }} | docker login -u ${{ secrets.registry_u }} --password-stdin
 
@@ -141,7 +185,10 @@ jobs:
 
       - name: Create and push multiplatform image
         run: |
-          docker pull ${IMAGE} || docker buildx imagetools create -t ${IMAGE} ${IMAGE}-amd64 ${IMAGE}-arm64
+          IMAGES=''
+          [ -n "${{ inputs.runner_amd64 }}" ] && IMAGES="${IMAGES} ${{ inputs.image }}-${{ inputs.amd64_tag }}"
+          [ -n "${{ inputs.runner_arm64 }}" ] && IMAGES="${IMAGES} ${{ inputs.image }}-${{ inputs.arm64_tag }}"
+          docker pull ${IMAGE} || docker buildx imagetools create -t ${IMAGE} ${IMAGES}
 
       - name: Logout of DockerHub registry
         run: docker logout

--- a/.github/workflows/buildx_amd_arm_image.yml
+++ b/.github/workflows/buildx_amd_arm_image.yml
@@ -145,7 +145,7 @@ jobs:
 
       - name: Set up Docker buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
         if:  matrix.platform.image
 
       - name: Buildx and push image
@@ -218,7 +218,7 @@ jobs:
 
       - name: Set up Docker buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Create and push multiplatform image
         run: |

--- a/.github/workflows/buildx_amd_arm_image.yml
+++ b/.github/workflows/buildx_amd_arm_image.yml
@@ -67,7 +67,9 @@ jobs:
           - name: arm64
             runner: ${{ inputs.runner_arm64 }}
     steps:
-      - uses: actions/checkout@v4
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
       - name: Image name
         run: echo "Image name [${{ inputs.image }}-${{ matrix.platform.name }}]"

--- a/.github/workflows/buildx_amd_arm_image.yml
+++ b/.github/workflows/buildx_amd_arm_image.yml
@@ -132,7 +132,7 @@ jobs:
     steps:
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         if:  matrix.platform.image
 
       - name: Image name

--- a/.github/workflows/buildx_push_image.yml
+++ b/.github/workflows/buildx_push_image.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Set up Docker buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: If not pull image, buildx and push image
         env:

--- a/.github/workflows/buildx_push_image.yml
+++ b/.github/workflows/buildx_push_image.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Image name
         run: echo "Image name [${IMAGE}]"

--- a/.github/workflows/buildx_push_image.yml
+++ b/.github/workflows/buildx_push_image.yml
@@ -38,7 +38,8 @@ jobs:
       IMAGE: ${{ inputs.image }}
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
       - name: Image name
         run: echo "Image name [${IMAGE}]"

--- a/.github/workflows/copy_image.yml
+++ b/.github/workflows/copy_image.yml
@@ -34,10 +34,10 @@ jobs:
       TARGET_IMAGE: ${{ inputs.target_image }}
 
     steps:
-      - name: Login to DockerHub Registry
+      - name: Login to DockerHub registry
         run: echo ${{ secrets.registry_p }} | docker login -u ${{ secrets.registry_u }} --password-stdin
 
-      - name: Set up Docker Buildx
+      - name: Set up Docker buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Copy image (buildx imagetools create)
@@ -46,7 +46,7 @@ jobs:
             --tag ${{ inputs.target_image }} \
             ${{ inputs.source_image }}
 
-      - name: Logout of DockerHub Registry
+      - name: Logout of DockerHub registry
         run: docker logout
 
       - name: Annotate copied image

--- a/.github/workflows/copy_image.yml
+++ b/.github/workflows/copy_image.yml
@@ -38,7 +38,7 @@ jobs:
         run: echo ${{ secrets.registry_p }} | docker login -u ${{ secrets.registry_u }} --password-stdin
 
       - name: Set up Docker buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Copy image (buildx imagetools create)
         run: |

--- a/.github/workflows/copy_image_to_latest.yml
+++ b/.github/workflows/copy_image_to_latest.yml
@@ -2,6 +2,15 @@ name: Copy Image To Latest
 
 on:
   workflow_call:
+
+    secrets:
+      registry_u:
+        description: The username for the docker login
+        required: true
+      registry_p:
+        description: The password (PAT) for the docker login
+        required: true
+
     inputs:
       runner:
         description: "The type of runner for this workflow (Default: ubuntu-latest)"
@@ -12,13 +21,6 @@ on:
         description: The image to copy to latest
         required: true
         type: string
-    secrets:
-      registry_u:
-        description: The username for the docker login
-        required: true
-      registry_p:
-        description: The password (PAT) for the docker login
-        required: true
 
 jobs:
 

--- a/.github/workflows/delete_docker_hub_repositories.yml
+++ b/.github/workflows/delete_docker_hub_repositories.yml
@@ -2,6 +2,15 @@ name: Delete Image Repositories
 
 on:
   workflow_call:
+
+    secrets:
+      registry_u:
+        description: The username for the docker login
+        required: true
+      registry_p:
+        description: The password (PAT) for the docker login
+        required: true
+
     inputs:
       runner:
         description: "The type of runner for this workflow (Default: ubuntu-latest)"
@@ -21,14 +30,6 @@ on:
         description: "The git reference for the action"
         required: false
         type: string
-
-    secrets:
-      registry_u:
-        description: The username for the docker login
-        required: true
-      registry_p:
-        description: The password (PAT) for the docker login
-        required: true
 
 jobs:
   delete-image-repository:

--- a/.github/workflows/delete_docker_hub_repositories.yml
+++ b/.github/workflows/delete_docker_hub_repositories.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout action repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           repository: brianjbayer/actions-image-cicd
           ref: ${{ inputs.ref }}

--- a/.github/workflows/get_merged_branch_last_commit.yml
+++ b/.github/workflows/get_merged_branch_last_commit.yml
@@ -26,7 +26,7 @@ jobs:
       commit: ${{ steps.getcommit.outputs.commit }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/git_detect_changed_files.yml
+++ b/.github/workflows/git_detect_changed_files.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/git_detect_changed_files.yml
+++ b/.github/workflows/git_detect_changed_files.yml
@@ -34,7 +34,7 @@ jobs:
       any_changed: ${{ steps.detect-changed-files.outputs.any_changed }}
 
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/.github/workflows/git_github_info.yml
+++ b/.github/workflows/git_github_info.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/git_github_info.yml
+++ b/.github/workflows/git_github_info.yml
@@ -15,7 +15,8 @@ jobs:
     runs-on: ${{ inputs.runner }}
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/image_names.yml
+++ b/.github/workflows/image_names.yml
@@ -100,7 +100,8 @@ jobs:
       name: ${{ steps.generate.outputs.base_name }}
 
     steps:
-      - id: generate
+      - name: Generate
+        id: generate
         run: |
           base_name=${{ inputs.image_base_name }}
 
@@ -132,7 +133,8 @@ jobs:
       dev_repository: ${{ steps.generate.outputs.dev_repository }}
 
     steps:
-      - id: generate
+      - name: Generate
+        id: generate
         run: |
           vetted_repository=${{ needs.generate-base-name.outputs.name }}
           echo "vetted_repository=${vetted_repository}" >> $GITHUB_OUTPUT
@@ -170,7 +172,8 @@ jobs:
       branch_build_cache_name: ${{ steps.generate.outputs.branch_cache }}
 
     steps:
-      - id: generate
+      - name: Generate
+        id: generate
         run: |
           edge_cache="${{ inputs.edge_build_cache_root }}${{ inputs.edge_build_cache_label }}:${{ inputs.build_cache_tag }}"
           echo "edge_cache=${edge_cache}" >> $GITHUB_OUTPUT

--- a/.github/workflows/normalize_for_image_name.yml
+++ b/.github/workflows/normalize_for_image_name.yml
@@ -30,7 +30,9 @@ jobs:
     steps:
       - name: Normalize input
         run: echo "Inputted RAW_NAME=[${RAW_NAME}]"
-      - id: normalize
+
+      - name: Normalize
+        id: normalize
         # Normalization...
         #  1. Convert non-alphanumeric to space and remove any duplicate spaces (tr -cs)
         #  2. Convert any uppercase letters to lowercase (tr '[:upper:]' '[:lower:]')

--- a/.github/workflows/on_pr_checks.yml
+++ b/.github/workflows/on_pr_checks.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
 
-    # --- Git and GitHub Info ---
+  # --- Git and GitHub Info ---
 
   check-git_github_info:
     name: Check Git and GitHub Info

--- a/.github/workflows/pr_merge_info.yml
+++ b/.github/workflows/pr_merge_info.yml
@@ -1,0 +1,141 @@
+name: PR Merge Info
+
+on:
+  workflow_call:
+
+    secrets:
+      github-token:
+        description: "Github Repository Access Token"
+        required: true
+
+    inputs:
+      github-owner-repo:
+        description: "The owner/repository of the PR"
+        required: false
+        type: string
+        default: ${{ github.repository }}
+
+      runner:
+        description: "The type of runner for this workflow (Default: ubuntu-latest)"
+        required: false
+        type: string
+        default: ubuntu-latest
+      summary:
+        description: "Add a summary report to the workflow run (Default: true)"
+        required: false
+        type: boolean
+        default: true
+      ref:
+        description: "The git reference for the action"
+        required: false
+        type: string
+      # TESTING: TODO set default: BRANCH
+
+    outputs:
+      branch:
+        description: The name of the merged branch (from merge comment)
+        value: ${{ jobs.merge-information.outputs.branch }}
+      last-commit:
+        description: The last commit on the branch (commit before merge commit)
+        value: ${{ jobs.merge-information.outputs.last-commit }}
+      merge-commit:
+        description: The last commit on the branch (commit before merge commit)
+        value: ${{ jobs.merge-information.outputs.merge-commit }}
+      pr-number:
+        description: "PR number"
+        value: ${{ jobs.merge-information.outputs.number }}
+      pr-title:
+        description: "PR Title"
+        value: ${{ jobs.merge-information.outputs.title }}
+      pr-url:
+        description: "PR URL"
+        value: ${{ jobs.merge-information.outputs.url }}
+      base-branch:
+        description: "Target branch of PR merge (base.ref)"
+        value: ${{ jobs.merge-information.outputs.base-branch }}
+      base-last-commit:
+        description: "Last commit on base branch before merge"
+        value: ${{ jobs.merge-information.outputs.base-last-commit }}
+
+jobs:
+  merge-information:
+    name: Merge Information
+    runs-on: ${{ inputs.runner }}
+    outputs:
+      last-commit: ${{ steps.git-log.outputs.last-commit }}
+      merge-commit: ${{ steps.git-log.outputs.merge-commit }}
+
+      branch: ${{ steps.merge-commit-pr.outputs.branch }}
+      number: ${{ steps.merge-commit-pr.outputs.number }}
+      title: ${{ steps.merge-commit-pr.outputs.title }}
+      url: ${{ steps.merge-commit-pr.outputs.url }}
+      base-branch: ${{ steps.merge-commit-pr.outputs.base-branch }}
+      base-last-commit: ${{ steps.merge-commit-pr.outputs.base-last-commit }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: The git log is the source of truth
+        id: git-log
+        run: |
+          echo "git log..."
+          git log
+
+          echo " --- "
+
+          merge_commit=$(git log -1 --pretty=%H)
+          echo "merge_commit: [$merge_commit]"
+          echo "merge-commit=${merge_commit}" >> $GITHUB_OUTPUT
+
+          echo " --- "
+
+          last_commit=$(git log -n 1 --skip 1 --pretty=format:"%H")
+          echo "last_commit: [$last_commit]"
+          echo "last-commit=${last_commit}" >> $GITHUB_OUTPUT
+
+      - name: Merge and last commit before merge
+        run: |
+          echo "Merge Commit [${{ steps.git-log.outputs.merge-commit }}]"
+          echo "Last Commit [${{ steps.git-log.outputs.last-commit }}]"
+
+      - name: Checkout action repository
+        uses: actions/checkout@v6
+        with:
+          repository: brianjbayer/actions-image-cicd
+          ref: ${{ inputs.ref }}
+          path: action-repo
+
+      - name: GitHub PR
+        id: merge-commit-pr
+        uses: ./action-repo/.github/actions/merge-commit-pr-info
+        with:
+          github_owner_repo: ${{ inputs.github-owner-repo }}
+          merge-commit-sha: ${{ steps.git-log.outputs.merge-commit }}
+          ref: ${{ inputs.ref }}
+          # Secrets
+          github-token: ${{ secrets.github-token }}
+
+      - name: Summary report
+        if: ${{ inputs.summary == true }}
+        run: |
+          cat <<EOF >> $GITHUB_STEP_SUMMARY
+          ### Merge Information
+
+          For ${{ github.repository }}
+
+          #### Git Log
+
+          * Merge Commit:              `${{ steps.git-log.outputs.merge-commit }}`
+          * Last Commit Before Merge : `${{ steps.git-log.outputs.last-commit }}`
+
+          #### PR Info
+
+          **PR# ${{ steps.merge-commit-pr.outputs.number }}: ${{ steps.merge-commit-pr.outputs.title }}**
+
+          URl: ${{ steps.merge-commit-pr.outputs.url }}
+
+          Merges branch `${{ steps.merge-commit-pr.outputs.branch }}` into `${{ steps.merge-commit-pr.outputs.base-branch }}`
+          at commit `${{ steps.git-log.outputs.merge-commit }}`, previous commit `${{ steps.merge-commit-pr.outputs.base-last-commit }}`
+          EOF

--- a/.github/workflows/refresh_amd_arm_build_cache.yml
+++ b/.github/workflows/refresh_amd_arm_build_cache.yml
@@ -61,7 +61,7 @@ jobs:
             runner: ${{ inputs.runner_arm64 }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build cache name
         run: echo "Build cache name [${{ inputs.build_cache_name }}-${{ matrix.platform.name }}]"

--- a/.github/workflows/refresh_amd_arm_build_cache.yml
+++ b/.github/workflows/refresh_amd_arm_build_cache.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Set up Docker buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Buildx and push cache
         env:

--- a/.github/workflows/refresh_amd_arm_build_cache.yml
+++ b/.github/workflows/refresh_amd_arm_build_cache.yml
@@ -60,7 +60,8 @@ jobs:
           - name: arm64
             runner: ${{ inputs.runner_arm64 }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
       - name: Build cache name
         run: echo "Build cache name [${{ inputs.build_cache_name }}-${{ matrix.platform.name }}]"

--- a/.github/workflows/run_hub_command.yml
+++ b/.github/workflows/run_hub_command.yml
@@ -1,0 +1,51 @@
+name: Idempotent Copy (Promote) Image
+
+on:
+  workflow_call:
+
+    secrets:
+      registry_u:
+        description: The username for the docker login
+        required: true
+      registry_p:
+        description: The password (PAT) for the docker login
+        required: true
+
+    inputs:
+      runner:
+        description: "The type of runner for this workflow (Default: ubuntu-latest)"
+        required: false
+        type: string
+        default: ubuntu-latest
+      title:
+        description: "The title for the command being run"
+        required: false
+        type: string
+        default: Run Command
+      command:
+        description: The command to run
+        required: true
+        type: string
+      command_title:
+        description: The title for the run command step
+        required: false
+        type: string
+        default: Run
+
+jobs:
+  login-docker-hub-run-command:
+    name: ${{ inputs.title }}
+    runs-on: ${{ inputs.runner }}
+
+    steps:
+      - name: Login to DockerHub registry
+        run: echo ${{ secrets.registry_p }} | docker login -u ${{ secrets.registry_u }} --password-stdin
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: ${{ inputs.command_title }}
+        run: ${{ inputs.command }}
+
+      - name: Logout of DockerHub registry
+        run: docker logout

--- a/.github/workflows/vet_code_standards.yml
+++ b/.github/workflows/vet_code_standards.yml
@@ -32,7 +32,7 @@ jobs:
     if: ${{ inputs.lint_command != '' }}
     runs-on: ${{ inputs.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: "Lint [ ${{ inputs.lint_command }} ]"
         run: ${{ inputs.lint_command }}
 
@@ -41,7 +41,7 @@ jobs:
     if: ${{ inputs.dependency_security_command != '' }}
     runs-on: ${{ inputs.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: "Dependency Scan [ ${{ inputs.dependency_security_command }} ]"
         run: ${{ inputs.dependency_security_command }}
 
@@ -50,7 +50,7 @@ jobs:
     if: ${{ inputs.static_security_command != '' }}
     runs-on: ${{ inputs.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: "Vet Static Security [ ${{ inputs.static_security_command }} ]"
         run: ${{ inputs.static_security_command }}
 
@@ -59,6 +59,6 @@ jobs:
     if: ${{ inputs.tests_command != '' }}
     runs-on: ${{ inputs.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: "Vet Tests [ ${{ inputs.tests_command }} ]"
         run: ${{ inputs.tests_command }}

--- a/.github/workflows/vet_hub_code_standards.yml
+++ b/.github/workflows/vet_hub_code_standards.yml
@@ -1,0 +1,88 @@
+name: Vet Code Standards
+
+on:
+  workflow_call:
+
+    secrets:
+      registry_u:
+        description: The username for the docker login
+        required: true
+      registry_p:
+        description: The password (PAT) for the docker login
+        required: true
+
+    inputs:
+      runner:
+        description: "The type of runner for this workflow (Default: ubuntu-latest)"
+        required: false
+        type: string
+        default: ubuntu-latest
+      lint_command:
+        description: The command to vet linting
+        required: false
+        type: string
+      dependency_security_command:
+        description: The command to vet dependency security
+        required: false
+        type: string
+      static_security_command:
+        description: The command to vet static security analysis
+        required: false
+        type: string
+      tests_command:
+        description: The command to run the tests
+        required: false
+        type: string
+
+jobs:
+  vet-linting:
+    name: Linting
+    if: ${{ inputs.lint_command != '' }}
+    uses: ./.github/workflows/run_hub_command.yml
+    with:
+      runner: ${{ inputs.runner }}
+      title: Vet Linting
+      command_title: Run lint
+      command: ${{ inputs.lint_command }}
+    secrets:
+      registry_u: ${{ secrets.registry_u }}
+      registry_p: ${{ secrets.registry_p }}
+
+  vet-dependency-security:
+    name: Dependency Security
+    if: ${{ inputs.dependency_security_command != '' }}
+    uses: ./.github/workflows/run_hub_command.yml
+    with:
+      runner: ${{ inputs.runner }}
+      title: Vet Dependency Security
+      command_title: Run dependency security scan
+      command: ${{ inputs.dependency_security_command }}
+    secrets:
+      registry_u: ${{ secrets.registry_u }}
+      registry_p: ${{ secrets.registry_p }}
+
+  vet-static-security:
+    name: Static Security
+    if: ${{ inputs.static_security_command != '' }}
+    uses: ./.github/workflows/run_hub_command.yml
+    with:
+      runner: ${{ inputs.runner }}
+      title: Vet Static Security
+      command_title: Run static security scan
+      command: ${{ inputs.static_security_command }}
+    secrets:
+      registry_u: ${{ secrets.registry_u }}
+      registry_p: ${{ secrets.registry_p }}
+
+  run-tests:
+    name: Tests
+    if: ${{ inputs.tests_command != '' }}
+    uses: ./.github/workflows/run_hub_command.yml
+    with:
+      runner: ${{ inputs.runner }}
+      title: Run Tests
+      command_title: Run tests
+      command: ${{ inputs.tests_command }}
+    secrets:
+      registry_u: ${{ secrets.registry_u }}
+      registry_p: ${{ secrets.registry_p }}


### PR DESCRIPTION
# What & Why

To Improve operational resiliency this changeset...
* Authorizes All (Hub) Image Pulls including by called `actions`
* Make Platform Image Builds Optional (`amd`, `arm`)
* Update `actions/checkout` to `v6`
* Update `docker/setup-buildx-action` to `v4`


## Development Notes

## Usage of `action` in Another Calling Repository Workflow
For a Docker-based GitHub Action called from another repository, the standard and correct authorization mechanism is:

* The caller workflow passes its ephemeral `GITHUB_TOKEN`
* `action` uses that token with Octokit
* The permissions are declared in the caller workflow

That token is automatically scoped to the calling repository, which is exactly what is needed to read PR info for the repository running the workflow.

Caller workflow...

```yaml
jobs:
  my_job:
    permissions:
      pull-requests: read
      contents: read

    runs-on: ubuntu-latest

    steps:
      - uses: brianjbayer/merge-commit-pr-info@v2
        with:
          github-token: ${{ secrets.GITHUB_TOKEN }}
```




# Change Impact Analysis and Testing
> Describe the specific impacts of your changes and how those impacts
> will be vetted.
>
> Delete this callout.
